### PR TITLE
Add centralized API service

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Session;
+use App\Services\ApiService;
 
 class LoginController extends Controller
 {
+    public function __construct(private ApiService $apiService)
+    {
+    }
     public function showLoginForm()
     {
         return view('login');
@@ -20,12 +23,9 @@ class LoginController extends Controller
             'password' => 'required',
         ]);
 
-        $response = Http::post('http://186.46.31.211:9090/isospam/login', $data);
+        $response = $this->apiService->login($data);
 
         if ($response->successful()) {
-            $json = $response->json();
-            Session::put('user', $json['persona']);
-            Session::put('token', $json['access_token']);
             return redirect('/');
         }
 

--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Http\Client\PendingRequest;
+
+class ApiService
+{
+    /**
+     * Base URL for API requests.
+     */
+    protected string $baseUrl = 'http://186.46.31.211:9090/isospam';
+
+    /**
+     * Perform login and store token in the session.
+     */
+    public function login(array $credentials)
+    {
+        $response = Http::post($this->baseUrl . '/login', $credentials);
+
+        if ($response->successful()) {
+            $json = $response->json();
+            Session::put('user', $json['persona'] ?? null);
+            Session::put('token', $json['access_token'] ?? null);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Create a request instance with the authorization token when available.
+     */
+    protected function withToken(): PendingRequest
+    {
+        $request = Http::baseUrl($this->baseUrl);
+
+        if (Session::has('token')) {
+            $request = $request->withToken(Session::get('token'));
+        }
+
+        return $request;
+    }
+
+    public function get(string $url, array $query = [])
+    {
+        return $this->withToken()->get($url, $query);
+    }
+
+    public function post(string $url, array $data = [])
+    {
+        return $this->withToken()->post($url, $data);
+    }
+
+    public function put(string $url, array $data = [])
+    {
+        return $this->withToken()->put($url, $data);
+    }
+
+    public function delete(string $url, array $data = [])
+    {
+        return $this->withToken()->delete($url, $data);
+    }
+}


### PR DESCRIPTION
## Summary
- create `ApiService` to centralize HTTP requests
- refactor `LoginController` to use new service
- include session token automatically for other API calls

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687f3211654c8333855e9fa009458907