### PR TITLE
Enable dark mode and roles display

### DIFF
--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -24,6 +24,7 @@ class ApiService
             $json = $response->json();
             Session::put('user', $json['persona'] ?? null);
             Session::put('token', $json['access_token'] ?? null);
+            Session::put('roles', $json['roles'] ?? []);
         }
 
         return $response;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,6 +7,22 @@
         @if(session('user'))
             <p>Nombre: {{ session('user.nombres') }} {{ session('user.apellidos') }}</p>
             <p>Email: {{ session('user.email') }}</p>
+
+            @if(session('roles'))
+                <h4 class="mt-4">Roles</h4>
+                @foreach(session('roles') as $rol)
+                    <div class="mb-3">
+                        <h5>{{ $rol['nombrerol'] ?? '' }}</h5>
+                        @if(!empty($rol['menu']))
+                            <ul class="ms-3">
+                                @foreach($rol['menu'] as $menu)
+                                    <li>{{ $menu['opcion'] ?? '' }}</li>
+                                @endforeach
+                            </ul>
+                        @endif
+                    </div>
+                @endforeach
+            @endif
         @else
             <p>No has iniciado sesión.</p>
         @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'Laravel') }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+<body class="bg-dark text-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
         <div class="container">
             <a class="navbar-brand" href="/">{{ config('app.name', 'Laravel') }}</a>
             <div class="collapse navbar-collapse">


### PR DESCRIPTION
## Summary
- update layout to bootstrap dark theme
- store `roles` on login
- show roles and menus on the home page

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687f348121748333a8034c16a7374154