### PR TITLE
Improve dashboard layout

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -1,0 +1,22 @@
+body {
+    background: linear-gradient(120deg, #0d1117, #1f2430);
+    color: #f8f9fa;
+    min-height: 100vh;
+}
+.navbar-brand {
+    font-weight: bold;
+    letter-spacing: 1px;
+}
+.card {
+    border: none;
+    background-color: #2c303a;
+}
+.card h5 {
+    color: #e2e8f0;
+}
+.menu-text {
+    transition: opacity 0.3s ease;
+}
+body.sidebar-collapsed .menu-text {
+    opacity: 0;
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,31 +1,42 @@
 @extends('layouts.dashboard')
 
 @section('content')
-<div class="row">
-    <div class="col-12">
-        <h3>Bienvenido</h3>
-        @if(session('user'))
-            <p>Nombre: {{ session('user.nombres') }} {{ session('user.apellidos') }}</p>
-            <p>Email: {{ session('user.email') }}</p>
-
-            @if(session('roles'))
-                <h4 class="mt-4">Roles</h4>
-                @foreach(session('roles') as $rol)
-                    <div class="mb-3">
-                        <h5>{{ $rol['nombrerol'] ?? '' }}</h5>
-                        @if(!empty($rol['menu']))
-                            <ul class="ms-3">
-                                @foreach($rol['menu'] as $menu)
-                                    <li>{{ $menu['opcion'] ?? '' }}</li>
-                                @endforeach
-                            </ul>
+<div class="container-fluid">
+    @if(session('user'))
+        <div class="row g-4">
+            <div class="col-md-4">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title mb-3">Usuario</h5>
+                        <p class="mb-1 fw-semibold">{{ session('user.nombres') }} {{ session('user.apellidos') }}</p>
+                        <p class="mb-0 text-muted">{{ session('user.email') }}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-8">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title mb-3">Roles</h5>
+                        @if(session('roles'))
+                            @foreach(session('roles') as $rol)
+                                <div class="mb-3">
+                                    <strong>{{ $rol['nombrerol'] ?? '' }}</strong>
+                                    @if(!empty($rol['menu']))
+                                        <ul class="ms-3 mt-1">
+                                            @foreach($rol['menu'] as $menu)
+                                                <li>{{ $menu['opcion'] ?? '' }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @endif
+                                </div>
+                            @endforeach
                         @endif
                     </div>
-                @endforeach
-            @endif
-        @else
-            <p>No has iniciado sesión.</p>
-        @endif
-    </div>
+                </div>
+            </div>
+        </div>
+    @else
+        <div class="alert alert-info">No has iniciado sesión.</div>
+    @endif
 </div>
 @endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -6,6 +6,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{ asset('css/dashboard.css') }}">
     <style>
         body { overflow-x: hidden; }
         main { margin-top: 56px; }


### PR DESCRIPTION
## Summary
- redesign dashboard layout with custom stylesheet
- add cards to the home dashboard page

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687f3a60f25c8333837cfd28944d46d5