### PR TITLE
Add Campania CRUD

### DIFF
--- a/app/Http/Controllers/CampaniaController.php
+++ b/app/Http/Controllers/CampaniaController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class CampaniaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/campanias');
+        $campanias = $response->successful() ? $response->json() : [];
+
+        return view('campanias.index', [
+            'campanias' => $campanias,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('campanias.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'fechainicio' => ['nullable', 'date'],
+            'fechafin' => ['nullable', 'date'],
+            'descripcion' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/campanias', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.index')->with('success', 'Campaña creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/campanias/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $campania = $response->json();
+        return view('campanias.form', [
+            'campania' => $campania,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'fechainicio' => ['nullable', 'date'],
+            'fechafin' => ['nullable', 'date'],
+            'descripcion' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/campanias/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.index')->with('success', 'Campaña actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/campanias/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.index')->with('success', 'Campaña eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/campanias/form.blade.php
+++ b/resources/views/campanias/form.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($campania) ? 'Editar' : 'Nueva' }} Campaña</h3>
+<form method="POST" action="{{ isset($campania) ? route('campanias.update', $campania['id']) : route('campanias.store') }}">
+    @csrf
+    @if(isset($campania))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Fecha Inicio</label>
+        <input type="date" name="fechainicio" class="form-control" value="{{ old('fechainicio', $campania['fechainicio'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Fecha Fin</label>
+        <input type="date" name="fechafin" class="form-control" value="{{ old('fechafin', $campania['fechafin'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Descripción</label>
+        <input type="text" name="descripcion" class="form-control" value="{{ old('descripcion', $campania['descripcion'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('campanias.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/campanias/index.blade.php
+++ b/resources/views/campanias/index.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Campañas</h3>
+    <a href="{{ route('campanias.create') }}" class="btn btn-primary">Nueva</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th>Descripción</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($campanias as $campania)
+        <tr>
+            <td>{{ $campania['fechainicio'] ?? '' }}</td>
+            <td>{{ $campania['fechafin'] ?? '' }}</td>
+            <td>{{ $campania['descripcion'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('campanias.edit', $campania['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('campanias.destroy', $campania['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -53,6 +53,12 @@
                             <p>Embarcaciones</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('campanias.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-bullhorn"></i>
+                            <p>Campañas</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\EmbarcacionController;
+use App\Http\Controllers\CampaniaController;
 
 Route::get('/', function () {
     return view('home');
@@ -14,4 +15,5 @@ Route::get('/logout', [LoginController::class, 'logout'])->middleware('ensure.lo
 
 Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('embarcaciones', EmbarcacionController::class)->except(['show']);
+    Route::resource('campanias', CampaniaController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement CampaniaController with CRUD calls to API
- create blades for listing and editing Campañas
- register campania resource routes
- add "Campañas" entry in sidebar menu

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68826f9d0c3083338e1a0acd66589b1d