### PR TITLE
Add muelle CRUD

### DIFF
--- a/app/Http/Controllers/MuelleController.php
+++ b/app/Http/Controllers/MuelleController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class MuelleController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/muelles');
+        $muelles = $response->successful() ? $response->json() : [];
+
+        return view('muelles.index', [
+            'muelles' => $muelles,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('muelles.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/muelles', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('muelles.index')->with('success', 'Muelle creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/muelles/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $muelle = $response->json();
+        return view('muelles.form', [
+            'muelle' => $muelle,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/muelles/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('muelles.index')->with('success', 'Muelle actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/muelles/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('muelles.index')->with('success', 'Muelle eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -65,6 +65,12 @@
                             <p>Puertos</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('muelles.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-water" ></i>
+                            <p>Muelles</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/muelles/form.blade.php
+++ b/resources/views/muelles/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($muelle) ? 'Editar' : 'Nuevo' }} Muelle</h3>
+<form method="POST" action="{{ isset($muelle) ? route('muelles.update', $muelle['id']) : route('muelles.store') }}">
+    @csrf
+    @if(isset($muelle))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $muelle['nombre'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('muelles.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/muelles/index.blade.php
+++ b/resources/views/muelles/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Muelles</h3>
+    <a href="{{ route('muelles.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($muelles as $muelle)
+        <tr>
+            <td>{{ $muelle['nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('muelles.edit', $muelle['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('muelles.destroy', $muelle['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\LoginController;
 use App\Http\Controllers\EmbarcacionController;
 use App\Http\Controllers\CampaniaController;
 use App\Http\Controllers\PuertoController;
+use App\Http\Controllers\MuelleController;
 
 Route::get('/', function () {
     return view('home');
@@ -18,4 +19,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('embarcaciones', EmbarcacionController::class)->except(['show']);
     Route::resource('campanias', CampaniaController::class)->except(['show']);
     Route::resource('puertos', PuertoController::class)->except(['show']);
+    Route::resource('muelles', MuelleController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- add MuelleController with CRUD endpoints to consume API
- create views for muelles list and form
- expose muelles routes
- link Muelles section from sidebar menu

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6882ab597ed8833399b879da3f7f2ee9