### PR TITLE
Add TipoArte CRUD interface

### DIFF
--- a/app/Http/Controllers/TipoArteController.php
+++ b/app/Http/Controllers/TipoArteController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class TipoArteController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/tipos-arte');
+        $tipoartes = $response->successful() ? $response->json() : [];
+
+        return view('tipoartes.index', [
+            'tipoartes' => $tipoartes,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('tipoartes.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'tipo' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/tipos-arte', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoartes.index')->with('success', 'Tipo de Arte creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/tipos-arte/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $tipoarte = $response->json();
+        return view('tipoartes.form', [
+            'tipoarte' => $tipoarte,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'tipo' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/tipos-arte/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoartes.index')->with('success', 'Tipo de Arte actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/tipos-arte/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('tipoartes.index')->with('success', 'Tipo de Arte eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -71,6 +71,12 @@
                             <p>Muelles</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('tipoartes.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-palette"></i>
+                            <p>Tipos de Arte</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/tipoartes/form.blade.php
+++ b/resources/views/tipoartes/form.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($tipoarte) ? 'Editar' : 'Nuevo' }} Tipo de Arte</h3>
+<form method="POST" action="{{ isset($tipoarte) ? route('tipoartes.update', $tipoarte['id']) : route('tipoartes.store') }}">
+    @csrf
+    @if(isset($tipoarte))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $tipoarte['nombre'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Tipo</label>
+        <input type="text" name="tipo" class="form-control" value="{{ old('tipo', $tipoarte['tipo'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('tipoartes.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/tipoartes/index.blade.php
+++ b/resources/views/tipoartes/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Tipos de Arte</h3>
+    <a href="{{ route('tipoartes.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Tipo</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($tipoartes as $tipo)
+        <tr>
+            <td>{{ $tipo['nombre'] ?? '' }}</td>
+            <td>{{ $tipo['tipo'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('tipoartes.edit', $tipo['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('tipoartes.destroy', $tipo['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\EmbarcacionController;
 use App\Http\Controllers\CampaniaController;
 use App\Http\Controllers\PuertoController;
 use App\Http\Controllers\MuelleController;
+use App\Http\Controllers\TipoArteController;
 
 Route::get('/', function () {
     return view('home');
@@ -20,4 +21,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('campanias', CampaniaController::class)->except(['show']);
     Route::resource('puertos', PuertoController::class)->except(['show']);
     Route::resource('muelles', MuelleController::class)->except(['show']);
+    Route::resource('tipoartes', TipoArteController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement `TipoArteController` using existing ApiService
- add views for listing and editing TipoArte
- add new routes for TipoArte resource
- show "Tipos de Arte" entry in sidebar

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6882ad5185108333aabf465e0301f378