### PR TITLE
Add TipoAnzuelo CRUD

### DIFF
--- a/app/Http/Controllers/TipoAnzueloController.php
+++ b/app/Http/Controllers/TipoAnzueloController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class TipoAnzueloController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/tipos-anzuelo');
+        $tiposanzuelo = $response->successful() ? $response->json() : [];
+
+        return view('tipoanzuelos.index', [
+            'tiposanzuelo' => $tiposanzuelo,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('tipoanzuelos.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/tipos-anzuelo', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoanzuelos.index')->with('success', 'Tipo de Anzuelo creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/tipos-anzuelo/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $tipoanzuelo = $response->json();
+        return view('tipoanzuelos.form', [
+            'tipoanzuelo' => $tipoanzuelo,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/tipos-anzuelo/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoanzuelos.index')->with('success', 'Tipo de Anzuelo actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/tipos-anzuelo/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('tipoanzuelos.index')->with('success', 'Tipo de Anzuelo eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -77,6 +77,12 @@
                             <p>Tipos de Arte</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('tipoanzuelos.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-fish"></i>
+                            <p>Tipos de Anzuelo</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/tipoanzuelos/form.blade.php
+++ b/resources/views/tipoanzuelos/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($tipoanzuelo) ? 'Editar' : 'Nuevo' }} Tipo de Anzuelo</h3>
+<form method="POST" action="{{ isset($tipoanzuelo) ? route('tipoanzuelos.update', $tipoanzuelo['id']) : route('tipoanzuelos.store') }}">
+    @csrf
+    @if(isset($tipoanzuelo))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $tipoanzuelo['nombre'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('tipoanzuelos.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/tipoanzuelos/index.blade.php
+++ b/resources/views/tipoanzuelos/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Tipos de Anzuelo</h3>
+    <a href="{{ route('tipoanzuelos.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($tiposanzuelo as $tipo)
+        <tr>
+            <td>{{ $tipo['nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('tipoanzuelos.edit', $tipo['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('tipoanzuelos.destroy', $tipo['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CampaniaController;
 use App\Http\Controllers\PuertoController;
 use App\Http\Controllers\MuelleController;
 use App\Http\Controllers\TipoArteController;
+use App\Http\Controllers\TipoAnzueloController;
 
 Route::get('/', function () {
     return view('home');
@@ -22,4 +23,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('puertos', PuertoController::class)->except(['show']);
     Route::resource('muelles', MuelleController::class)->except(['show']);
     Route::resource('tipoartes', TipoArteController::class)->except(['show']);
+    Route::resource('tipoanzuelos', TipoAnzueloController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- create `TipoAnzueloController` that consumes `/tipos-anzuelo` endpoints
- add new blade views for listing and editing hook types
- register `tipoanzuelos` resource routes
- link the new section in the sidebar menu

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688302ff5e088333a2b43f9b1bd57182