### PR TITLE
Add MaterialMalla CRUD

### DIFF
--- a/app/Http/Controllers/MaterialMallaController.php
+++ b/app/Http/Controllers/MaterialMallaController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class MaterialMallaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/materiales-malla');
+        $materiales = $response->successful() ? $response->json() : [];
+
+        return view('materialesmalla.index', [
+            'materialesmalla' => $materiales,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('materialesmalla.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/materiales-malla', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('materialesmalla.index')->with('success', 'Material de Malla creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/materiales-malla/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $materialmalla = $response->json();
+        return view('materialesmalla.form', [
+            'materialmalla' => $materialmalla,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/materiales-malla/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('materialesmalla.index')->with('success', 'Material de Malla actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/materiales-malla/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('materialesmalla.index')->with('success', 'Material de Malla eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -83,6 +83,12 @@
                             <p>Tipos de Anzuelo</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('materialesmalla.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-layer-group"></i>
+                            <p>Materiales de Malla</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/materialesmalla/form.blade.php
+++ b/resources/views/materialesmalla/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($materialmalla) ? 'Editar' : 'Nuevo' }} Material de Malla</h3>
+<form method="POST" action="{{ isset($materialmalla) ? route('materialesmalla.update', $materialmalla['id']) : route('materialesmalla.store') }}">
+    @csrf
+    @if(isset($materialmalla))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $materialmalla['nombre'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('materialesmalla.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/materialesmalla/index.blade.php
+++ b/resources/views/materialesmalla/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Materiales de Malla</h3>
+    <a href="{{ route('materialesmalla.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($materialesmalla as $material)
+        <tr>
+            <td>{{ $material['nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('materialesmalla.edit', $material['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('materialesmalla.destroy', $material['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\PuertoController;
 use App\Http\Controllers\MuelleController;
 use App\Http\Controllers\TipoArteController;
 use App\Http\Controllers\TipoAnzueloController;
+use App\Http\Controllers\MaterialMallaController;
 
 Route::get('/', function () {
     return view('home');
@@ -24,4 +25,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('muelles', MuelleController::class)->except(['show']);
     Route::resource('tipoartes', TipoArteController::class)->except(['show']);
     Route::resource('tipoanzuelos', TipoAnzueloController::class)->except(['show']);
+    Route::resource('materialesmalla', MaterialMallaController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement MaterialMallaController calling `/materiales-malla` API endpoints
- create views for listing and editing MaterialMalla
- expose new routes
- add link to sidebar menu

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688305e47d6083339267c67401ab4fbb