### PR TITLE
Add UnidadProfundidad CRUD

### DIFF
--- a/app/Http/Controllers/UnidadProfundidadController.php
+++ b/app/Http/Controllers/UnidadProfundidadController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class UnidadProfundidadController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/unidad-profundidad');
+        $unidades = $response->successful() ? $response->json() : [];
+
+        return view('unidadprofundidad.index', [
+            'unidades' => $unidades,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('unidadprofundidad.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'abreviatura' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/unidad-profundidad', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadprofundidad.index')->with('success', 'Unidad de Profundidad creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/unidad-profundidad/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $unidad = $response->json();
+
+        return view('unidadprofundidad.form', [
+            'unidad' => $unidad,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'abreviatura' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/unidad-profundidad/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadprofundidad.index')->with('success', 'Unidad de Profundidad actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/unidad-profundidad/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('unidadprofundidad.index')->with('success', 'Unidad de Profundidad eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -95,6 +95,12 @@
                             <p>Sitios</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('unidadprofundidad.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-ruler-vertical"></i>
+                            <p>Unidad Profundidad</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/unidadprofundidad/form.blade.php
+++ b/resources/views/unidadprofundidad/form.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($unidad) ? 'Editar' : 'Nuevo' }} Unidad de Profundidad</h3>
+<form method="POST" action="{{ isset($unidad) ? route('unidadprofundidad.update', $unidad['id']) : route('unidadprofundidad.store') }}">
+    @csrf
+    @if(isset($unidad))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $unidad['nombre'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Abreviatura</label>
+        <input type="text" name="abreviatura" class="form-control" value="{{ old('abreviatura', $unidad['abreviatura'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('unidadprofundidad.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/unidadprofundidad/index.blade.php
+++ b/resources/views/unidadprofundidad/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Unidades de Profundidad</h3>
+    <a href="{{ route('unidadprofundidad.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Abreviatura</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($unidades as $unidad)
+        <tr>
+            <td>{{ $unidad['nombre'] ?? '' }}</td>
+            <td>{{ $unidad['abreviatura'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('unidadprofundidad.edit', $unidad['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('unidadprofundidad.destroy', $unidad['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\TipoArteController;
 use App\Http\Controllers\TipoAnzueloController;
 use App\Http\Controllers\MaterialMallaController;
 use App\Http\Controllers\SitioController;
+use App\Http\Controllers\UnidadProfundidadController;
 
 Route::get('/', function () {
     return view('home');
@@ -28,4 +29,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('tipoanzuelos', TipoAnzueloController::class)->except(['show']);
     Route::resource('materialesmalla', MaterialMallaController::class)->except(['show']);
     Route::resource('sitios', SitioController::class)->except(['show']);
+    Route::resource('unidadprofundidad', UnidadProfundidadController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement UnidadProfundidadController with API calls
- create Blade templates for UnidadProfundidad
- add menu entry and web routes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68830b1bf35883338f3edd8ecc02417a