### PR TITLE
Add UnidadInsumo CRUD

### DIFF
--- a/app/Http/Controllers/UnidadInsumoController.php
+++ b/app/Http/Controllers/UnidadInsumoController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class UnidadInsumoController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/unidades-insumo');
+        $unidades = $response->successful() ? $response->json() : [];
+
+        return view('unidadesinsumo.index', [
+            'unidades' => $unidades,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('unidadesinsumo.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'abreviatura' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/unidades-insumo', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadesinsumo.index')->with('success', 'Unidad de Insumo creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/unidades-insumo/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $unidad = $response->json();
+
+        return view('unidadesinsumo.form', [
+            'unidad' => $unidad,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'abreviatura' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/unidades-insumo/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadesinsumo.index')->with('success', 'Unidad de Insumo actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/unidades-insumo/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('unidadesinsumo.index')->with('success', 'Unidad de Insumo eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -107,6 +107,12 @@
                             <p>Unidad Profundidad</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('unidadesinsumo.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-weight-hanging"></i>
+                            <p>Unidades de Insumo</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/unidadesinsumo/form.blade.php
+++ b/resources/views/unidadesinsumo/form.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($unidad) ? 'Editar' : 'Nueva' }} Unidad de Insumo</h3>
+<form method="POST" action="{{ isset($unidad) ? route('unidadesinsumo.update', $unidad['id']) : route('unidadesinsumo.store') }}">
+    @csrf
+    @if(isset($unidad))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $unidad['nombre'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Abreviatura</label>
+        <input type="text" name="abreviatura" class="form-control" value="{{ old('abreviatura', $unidad['abreviatura'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('unidadesinsumo.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/unidadesinsumo/index.blade.php
+++ b/resources/views/unidadesinsumo/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Unidades de Insumo</h3>
+    <a href="{{ route('unidadesinsumo.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Abreviatura</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($unidades as $unidad)
+        <tr>
+            <td>{{ $unidad['nombre'] ?? '' }}</td>
+            <td>{{ $unidad['abreviatura'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('unidadesinsumo.edit', $unidad['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('unidadesinsumo.destroy', $unidad['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\MaterialMallaController;
 use App\Http\Controllers\SitioController;
 use App\Http\Controllers\UnidadProfundidadController;
 use App\Http\Controllers\TipoInsumoController;
+use App\Http\Controllers\UnidadInsumoController;
 
 Route::get('/', function () {
     return view('home');
@@ -32,4 +33,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('materialesmalla', MaterialMallaController::class)->except(['show']);
     Route::resource('sitios', SitioController::class)->except(['show']);
     Route::resource('unidadprofundidad', UnidadProfundidadController::class)->except(['show']);
+    Route::resource('unidadesinsumo', UnidadInsumoController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement UnidadInsumoController calling API endpoints
- create views for Unidad Insumo management
- register routes and sidebar link

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6883113edf908333903404248dd98ce3