### PR TITLE
Add Familia CRUD to dashboard

### DIFF
--- a/app/Http/Controllers/FamiliaController.php
+++ b/app/Http/Controllers/FamiliaController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class FamiliaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/familias');
+        $familias = $response->successful() ? $response->json() : [];
+
+        return view('familias.index', [
+            'familias' => $familias,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('familias.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/familias', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('familias.index')->with('success', 'Familia creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/familias/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $familia = $response->json();
+        return view('familias.form', [
+            'familia' => $familia,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/familias/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('familias.index')->with('success', 'Familia actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/familias/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('familias.index')->with('success', 'Familia eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/familias/form.blade.php
+++ b/resources/views/familias/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($familia) ? 'Editar' : 'Nueva' }} Familia</h3>
+<form method="POST" action="{{ isset($familia) ? route('familias.update', $familia['id']) : route('familias.store') }}">
+    @csrf
+    @if(isset($familia))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $familia['nombre'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('familias.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/familias/index.blade.php
+++ b/resources/views/familias/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Familias</h3>
+    <a href="{{ route('familias.create') }}" class="btn btn-primary">Nueva</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($familias as $familia)
+        <tr>
+            <td>{{ $familia['nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('familias.edit', $familia['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('familias.destroy', $familia['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -137,6 +137,12 @@
                             <p>Personas</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('familias.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-fish"></i>
+                            <p>Familias</p>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\CondicionMarController;
 use App\Http\Controllers\TipoTripulanteController;
 use App\Http\Controllers\PersonaController;
 use App\Http\Controllers\EstadoMareaController;
+use App\Http\Controllers\FamiliaController;
 
 Route::get('/', function () {
     return view('home');
@@ -42,4 +43,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('condicionesmar', CondicionMarController::class)->except(['show']);
     Route::resource('estadosmarea', EstadoMareaController::class)->except(['show']);
     Route::resource('personas', PersonaController::class)->except(['show']);
+    Route::resource('familias', FamiliaController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement FamiliaController with basic CRUD calls to API
- add Familia views for listing and editing
- register familia routes and sidebar link

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68859a2bbc0483338b7cd96cb2543b2f