### PR TITLE
Implement Especie CRUD with family integration

### DIFF
--- a/app/Http/Controllers/EspecieController.php
+++ b/app/Http/Controllers/EspecieController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class EspecieController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $familiaId = $request->query('familia_id');
+        if ($familiaId) {
+            $response = $this->apiService->get('/especies/por-familia', ['familia_id' => $familiaId]);
+        } else {
+            $response = $this->apiService->get('/especies');
+        }
+        $especies = $response->successful() ? $response->json() : [];
+        $familia = null;
+        if ($familiaId) {
+            $respFamilia = $this->apiService->get("/familias/{$familiaId}");
+            if ($respFamilia->successful()) {
+                $familia = $respFamilia->json();
+            }
+        }
+        return view('especies.index', [
+            'especies' => $especies,
+            'familiaId' => $familiaId,
+            'familia' => $familia,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        $familias = $this->getFamilias();
+        $familiaId = $request->query('familia_id');
+        return view('especies.form', [
+            'familias' => $familias,
+            'familiaId' => $familiaId,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'familia_id' => ['required', 'integer'],
+        ]);
+
+        $response = $this->apiService->post('/especies', $data);
+
+        if ($response->successful()) {
+            $redirect = $data['familia_id']
+                ? route('especies.index', ['familia_id' => $data['familia_id']])
+                : route('especies.index');
+            return redirect($redirect)->with('success', 'Especie creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/especies/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $especie = $response->json();
+        $familias = $this->getFamilias();
+        return view('especies.form', [
+            'especie' => $especie,
+            'familias' => $familias,
+            'familiaId' => $especie['familia_id'] ?? null,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+            'familia_id' => ['required', 'integer'],
+        ]);
+
+        $response = $this->apiService->put("/especies/{$id}", $data);
+
+        if ($response->successful()) {
+            $redirect = $data['familia_id']
+                ? route('especies.index', ['familia_id' => $data['familia_id']])
+                : route('especies.index');
+            return redirect($redirect)->with('success', 'Especie actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(Request $request, string $id)
+    {
+        $familiaId = $request->query('familia_id');
+        $response = $this->apiService->delete("/especies/{$id}");
+
+        if ($response->successful()) {
+            $redirect = $familiaId
+                ? route('especies.index', ['familia_id' => $familiaId])
+                : route('especies.index');
+            return redirect($redirect)->with('success', 'Especie eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getFamilias(): array
+    {
+        $response = $this->apiService->get('/familias');
+        return $response->successful() ? $response->json() : [];
+    }
+}

--- a/resources/views/especies/form.blade.php
+++ b/resources/views/especies/form.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($especie) ? 'Editar' : 'Nueva' }} Especie</h3>
+<form method="POST" action="{{ isset($especie) ? route('especies.update', $especie['id']) : route('especies.store') }}">
+    @csrf
+    @if(isset($especie))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $especie['nombre'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Familia</label>
+        <select name="familia_id" class="form-control" required>
+            <option value="">Seleccione...</option>
+            @foreach($familias as $familia)
+                <option value="{{ $familia['id'] }}" @selected(old('familia_id', $familiaId ?? ($especie['familia_id'] ?? '')) == $familia['id'])>
+                    {{ $familia['nombre'] ?? '' }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    @if($familiaId)
+        <a href="{{ route('especies.index', ['familia_id' => $familiaId]) }}" class="btn btn-secondary">Cancelar</a>
+    @else
+        <a href="{{ route('especies.index') }}" class="btn btn-secondary">Cancelar</a>
+    @endif
+</form>
+@endsection

--- a/resources/views/especies/index.blade.php
+++ b/resources/views/especies/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Especies @if($familia) de {{ $familia['nombre'] ?? '' }} @endif</h3>
+    <a href="{{ route('especies.create', $familiaId ? ['familia_id' => $familiaId] : []) }}" class="btn btn-primary">Nueva</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Familia</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($especies as $esp)
+        <tr>
+            <td>{{ $esp['nombre'] ?? '' }}</td>
+            <td>{{ $esp['familia_nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('especies.edit', $esp['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('especies.destroy', $esp['id']) }}{{ $familiaId ? '?familia_id='.$familiaId : '' }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@if($familiaId)
+    <a href="{{ route('familias.index') }}" class="btn btn-secondary mt-2">Volver a Familias</a>
+@endif
+@endsection

--- a/resources/views/familias/index.blade.php
+++ b/resources/views/familias/index.blade.php
@@ -24,6 +24,7 @@
             <td>{{ $familia['nombre'] ?? '' }}</td>
             <td class="text-right">
                 <a href="{{ route('familias.edit', $familia['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <a href="{{ route('especies.index', ['familia_id' => $familia['id']]) }}" class="btn btn-sm btn-info">Especies</a>
                 <form action="{{ route('familias.destroy', $familia['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
                     @csrf
                     @method('DELETE')

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -137,11 +137,28 @@
                             <p>Personas</p>
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a href="{{ route('familias.index') }}" class="nav-link">
+                    <li class="nav-item has-treeview">
+                        <a href="#" class="nav-link">
                             <i class="nav-icon fas fa-fish"></i>
-                            <p>Familias</p>
+                            <p>
+                                Familias
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
                         </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('familias.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Familias</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('especies.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Especies</p>
+                                </a>
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\TipoTripulanteController;
 use App\Http\Controllers\PersonaController;
 use App\Http\Controllers\EstadoMareaController;
 use App\Http\Controllers\FamiliaController;
+use App\Http\Controllers\EspecieController;
 
 Route::get('/', function () {
     return view('home');
@@ -44,4 +45,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('estadosmarea', EstadoMareaController::class)->except(['show']);
     Route::resource('personas', PersonaController::class)->except(['show']);
     Route::resource('familias', FamiliaController::class)->except(['show']);
+    Route::resource('especies', EspecieController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- create `EspecieController` to consume API endpoints
- add views to manage species
- link species from each family in families index
- nest new menu option under **Familias** in sidebar
- expose species routes

## Testing
- `composer install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68859d9356fc8333acd3da6964f9de64