### PR TITLE
Add TipoObservador CRUD

### DIFF
--- a/app/Http/Controllers/TipoObservadorController.php
+++ b/app/Http/Controllers/TipoObservadorController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class TipoObservadorController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/tipo-observador');
+        $tipos = $response->successful() ? $response->json() : [];
+
+        return view('tipoobservador.index', [
+            'tiposobservador' => $tipos,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('tipoobservador.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'descripcion' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/tipo-observador', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoobservador.index')->with('success', 'Tipo de Observador creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/tipo-observador/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $tipo = $response->json();
+        return view('tipoobservador.form', [
+            'tipoobservador' => $tipo,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'descripcion' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/tipo-observador/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('tipoobservador.index')->with('success', 'Tipo de Observador actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/tipo-observador/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('tipoobservador.index')->with('success', 'Tipo de Observador eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -120,6 +120,12 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="{{ route('tipoobservador.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-eye"></i>
+                            <p>Tipos de Observador</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="{{ route('unidadesinsumo.index') }}" class="nav-link">
                             <i class="nav-icon fas fa-weight-hanging"></i>
                             <p>Unidades de Insumo</p>

--- a/resources/views/tipoobservador/form.blade.php
+++ b/resources/views/tipoobservador/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($tipoobservador) ? 'Editar' : 'Nuevo' }} Tipo de Observador</h3>
+<form method="POST" action="{{ isset($tipoobservador) ? route('tipoobservador.update', $tipoobservador['id']) : route('tipoobservador.store') }}">
+    @csrf
+    @if(isset($tipoobservador))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Descripción</label>
+        <input type="text" name="descripcion" class="form-control" value="{{ old('descripcion', $tipoobservador['descripcion'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('tipoobservador.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/tipoobservador/index.blade.php
+++ b/resources/views/tipoobservador/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Tipos de Observador</h3>
+    <a href="{{ route('tipoobservador.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Descripción</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($tiposobservador as $tipo)
+        <tr>
+            <td>{{ $tipo['descripcion'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('tipoobservador.edit', $tipo['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('tipoobservador.destroy', $tipo['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\UnidadInsumoController;
 use App\Http\Controllers\CondicionMarController;
 use App\Http\Controllers\TipoTripulanteController;
 use App\Http\Controllers\TipoMotorController;
+use App\Http\Controllers\TipoObservadorController;
 use App\Http\Controllers\PersonaController;
 use App\Http\Controllers\EstadoMareaController;
 use App\Http\Controllers\FamiliaController;
@@ -42,6 +43,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('unidadprofundidad', UnidadProfundidadController::class)->except(['show']);
     Route::resource('tipotripulantes', TipoTripulanteController::class)->except(['show']);
     Route::resource('tipomotores', TipoMotorController::class)->except(['show']);
+    Route::resource('tipoobservador', TipoObservadorController::class)->except(['show']);
     Route::resource('unidadesinsumo', UnidadInsumoController::class)->except(['show']);
     Route::resource('condicionesmar', CondicionMarController::class)->except(['show']);
     Route::resource('estadosmarea', EstadoMareaController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- implement `TipoObservadorController`
- add routes for TipoObservador
- create views for listing and editing types of observers
- link Tipo Observador in sidebar menu

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6885abe6c1f08333860d4fc3c1d33207