### PR TITLE
Add UnidadVenta CRUD

### DIFF
--- a/app/Http/Controllers/UnidadVentaController.php
+++ b/app/Http/Controllers/UnidadVentaController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class UnidadVentaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/unidad-venta');
+        $unidades = $response->successful() ? $response->json() : [];
+
+        return view('unidadventa.index', [
+            'unidades' => $unidades,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('unidadventa.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/unidad-venta', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadventa.index')->with('success', 'Unidad de Venta creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/unidad-venta/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $unidad = $response->json();
+
+        return view('unidadventa.form', [
+            'unidad' => $unidad,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/unidad-venta/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('unidadventa.index')->with('success', 'Unidad de Venta actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/unidad-venta/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('unidadventa.index')->with('success', 'Unidad de Venta eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -132,6 +132,12 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="{{ route('unidadventa.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-cash-register"></i>
+                            <p>Unidades de Venta</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="{{ route('condicionesmar.index') }}" class="nav-link">
                             <i class="nav-icon fas fa-water"></i>
                             <p>Condiciones del Mar</p>

--- a/resources/views/unidadventa/form.blade.php
+++ b/resources/views/unidadventa/form.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($unidad) ? 'Editar' : 'Nueva' }} Unidad de Venta</h3>
+<form method="POST" action="{{ isset($unidad) ? route('unidadventa.update', $unidad['id']) : route('unidadventa.store') }}">
+    @csrf
+    @if(isset($unidad))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="{{ old('nombre', $unidad['nombre'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('unidadventa.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/unidadventa/index.blade.php
+++ b/resources/views/unidadventa/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Unidades de Venta</h3>
+    <a href="{{ route('unidadventa.create') }}" class="btn btn-primary">Nueva</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($unidades as $unidad)
+        <tr>
+            <td>{{ $unidad['nombre'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('unidadventa.edit', $unidad['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('unidadventa.destroy', $unidad['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\SitioController;
 use App\Http\Controllers\UnidadProfundidadController;
 use App\Http\Controllers\TipoInsumoController;
 use App\Http\Controllers\UnidadInsumoController;
+use App\Http\Controllers\UnidadVentaController;
 use App\Http\Controllers\CondicionMarController;
 use App\Http\Controllers\TipoTripulanteController;
 use App\Http\Controllers\TipoMotorController;
@@ -45,6 +46,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('tipomotores', TipoMotorController::class)->except(['show']);
     Route::resource('tipoobservador', TipoObservadorController::class)->except(['show']);
     Route::resource('unidadesinsumo', UnidadInsumoController::class)->except(['show']);
+    Route::resource('unidadventa', UnidadVentaController::class)->except(['show']);
     Route::resource('condicionesmar', CondicionMarController::class)->except(['show']);
     Route::resource('estadosmarea', EstadoMareaController::class)->except(['show']);
     Route::resource('personas', PersonaController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- implement UnidadVentaController using API endpoints
- add UnidadVenta views
- include UnidadVenta menu option
- register UnidadVenta resource routes

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6885b91df2f4833383ab572bb0a5a031