### PR TITLE
Add AsignacionResponsable CRUD

### DIFF
--- a/app/Http/Controllers/AsignacionResponsableController.php
+++ b/app/Http/Controllers/AsignacionResponsableController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class AsignacionResponsableController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/asignaciones-responsables');
+        $asignaciones = $response->successful() ? $response->json() : [];
+
+        return view('asignacionresponsable.index', [
+            'asignaciones' => $asignaciones,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('asignacionresponsable.form', [
+            'organizaciones' => $this->getOrganizaciones(),
+            'personas' => $this->getPersonas(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'organizacion_pesquera_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+            'fecha_inicio' => ['nullable', 'date'],
+            'fecha_fin' => ['nullable', 'date'],
+            'estado' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/asignaciones-responsables', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('asignacionresponsable.index')->with('success', 'Asignación creada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/asignaciones-responsables/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $asignacion = $response->json();
+
+        return view('asignacionresponsable.form', [
+            'asignacion' => $asignacion,
+            'organizaciones' => $this->getOrganizaciones(),
+            'personas' => $this->getPersonas(),
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'organizacion_pesquera_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+            'fecha_inicio' => ['nullable', 'date'],
+            'fecha_fin' => ['nullable', 'date'],
+            'estado' => ['nullable', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/asignaciones-responsables/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('asignacionresponsable.index')->with('success', 'Asignación actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/asignaciones-responsables/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('asignacionresponsable.index')->with('success', 'Asignación eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getOrganizaciones(): array
+    {
+        $response = $this->apiService->get('/organizacion-pesquera');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getPersonas(): array
+    {
+        $response = $this->apiService->get('/personas');
+        return $response->successful() ? $response->json() : [];
+    }
+}

--- a/resources/views/asignacionresponsable/form.blade.php
+++ b/resources/views/asignacionresponsable/form.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($asignacion) ? 'Editar' : 'Nueva' }} Asignación Responsable</h3>
+<form method="POST" action="{{ isset($asignacion) ? route('asignacionresponsable.update', $asignacion['id']) : route('asignacionresponsable.store') }}">
+    @csrf
+    @if(isset($asignacion))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Organización Pesquera</label>
+        <select name="organizacion_pesquera_id" class="form-control" required>
+            <option value="">Seleccione...</option>
+            @foreach($organizaciones as $org)
+                <option value="{{ $org['id'] }}" @selected(old('organizacion_pesquera_id', $asignacion['organizacion_pesquera_id'] ?? '') == $org['id'])>
+                    {{ $org['nombre'] ?? $org['id'] }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Persona Responsable</label>
+        <select name="persona_idpersona" class="form-control" required>
+            <option value="">Seleccione...</option>
+            @foreach($personas as $per)
+                <option value="{{ $per['idpersona'] }}" @selected(old('persona_idpersona', $asignacion['persona_idpersona'] ?? '') == $per['idpersona'])>
+                    {{ $per['nombres'] ?? '' }} {{ $per['apellidos'] ?? '' }} - {{ $per['identificacion'] ?? '' }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Fecha Inicio</label>
+        <input type="date" name="fecha_inicio" class="form-control" value="{{ old('fecha_inicio', $asignacion['fecha_inicio'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Fecha Fin</label>
+        <input type="date" name="fecha_fin" class="form-control" value="{{ old('fecha_fin', $asignacion['fecha_fin'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Estado</label>
+        <input type="text" name="estado" class="form-control" value="{{ old('estado', $asignacion['estado'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('asignacionresponsable.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/asignacionresponsable/index.blade.php
+++ b/resources/views/asignacionresponsable/index.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Asignaciones de Responsable</h3>
+    <a href="{{ route('asignacionresponsable.create') }}" class="btn btn-primary">Nueva</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Organización</th>
+            <th>Responsable</th>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th>Estado</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($asignaciones as $asignacion)
+        <tr>
+            <td>{{ $asignacion['organizacion_nombre'] ?? '' }}</td>
+            <td>{{ ($asignacion['nombres'] ?? '') . ' ' . ($asignacion['apellidos'] ?? '') }}</td>
+            <td>{{ $asignacion['fecha_inicio'] ?? '' }}</td>
+            <td>{{ $asignacion['fecha_fin'] ?? '' }}</td>
+            <td>{{ $asignacion['estado'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('asignacionresponsable.edit', $asignacion['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -173,6 +173,12 @@
                             <p>Personas</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="{{ route('asignacionresponsable.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-user-tie"></i>
+                            <p>Asignar Responsable</p>
+                        </a>
+                    </li>
                     <li class="nav-item has-treeview">
                         <a href="#" class="nav-link">
                             <i class="nav-icon fas fa-fish"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\EstadoDesarrolloGonadalController;
 use App\Http\Controllers\FamiliaController;
 use App\Http\Controllers\EspecieController;
 use App\Http\Controllers\OrganizacionPesqueraController;
+use App\Http\Controllers\AsignacionResponsableController;
 
 Route::get('/', function () {
     return view('home');
@@ -58,4 +59,5 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('familias', FamiliaController::class)->except(['show']);
     Route::resource('especies', EspecieController::class)->except(['show']);
     Route::resource('organizacionpesquera', OrganizacionPesqueraController::class)->except(['show']);
+    Route::resource('asignacionresponsable', AsignacionResponsableController::class)->except(['show']);
 });


### PR DESCRIPTION
## Summary
- implement `AsignacionResponsableController` using API endpoints
- create blades for listing and editing assignments
- register resource route and show in side menu

## Testing
- `composer install --no-interaction`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6885c9b3239c833383135443d2f7585c