### PR TITLE
Show responsables when editing an organization

### DIFF
--- a/app/Http/Controllers/AsignacionResponsableController.php
+++ b/app/Http/Controllers/AsignacionResponsableController.php
@@ -21,11 +21,12 @@ class AsignacionResponsableController extends Controller
         ]);
     }
 
-    public function create()
+    public function create(Request $request)
     {
         return view('asignacionresponsable.form', [
             'organizaciones' => $this->getOrganizaciones(),
             'personas' => $this->getPersonas(),
+            'selectedOrganizacion' => $request->query('organizacion_pesquera_id'),
         ]);
     }
 
@@ -55,6 +56,12 @@ class AsignacionResponsableController extends Controller
             abort(404);
         }
         $asignacion = $response->json();
+        if (isset($asignacion[0]) && is_array($asignacion[0])) {
+            $asignacion = $asignacion[0];
+        }
+        if (! is_array($asignacion)) {
+            abort(404);
+        }
 
         return view('asignacionresponsable.form', [
             'asignacion' => $asignacion,

--- a/app/Http/Controllers/OrganizacionPesqueraController.php
+++ b/app/Http/Controllers/OrganizacionPesqueraController.php
@@ -52,8 +52,12 @@ class OrganizacionPesqueraController extends Controller
             abort(404);
         }
         $organizacion = $response->json();
+        $asignacionesResponse = $this->apiService->get("/asignaciones-responsables/organizacion/{$id}");
+        $asignaciones = $asignacionesResponse->successful() ? $asignacionesResponse->json() : [];
+
         return view('organizacionpesquera.form', [
             'organizacion' => $organizacion,
+            'asignaciones' => $asignaciones,
         ]);
     }
 

--- a/resources/views/asignacionresponsable/form.blade.php
+++ b/resources/views/asignacionresponsable/form.blade.php
@@ -12,7 +12,7 @@
         <select name="organizacion_pesquera_id" class="form-control" required>
             <option value="">Seleccione...</option>
             @foreach($organizaciones as $org)
-                <option value="{{ $org['id'] }}" @selected(old('organizacion_pesquera_id', $asignacion['organizacion_pesquera_id'] ?? '') == $org['id'])>
+                <option value="{{ $org['id'] }}" @selected(old('organizacion_pesquera_id', $asignacion['organizacion_pesquera_id'] ?? ($selectedOrganizacion ?? '')) == $org['id'])>
                     {{ $org['nombre'] ?? $org['id'] }}
                 </option>
             @endforeach

--- a/resources/views/organizacionpesquera/form.blade.php
+++ b/resources/views/organizacionpesquera/form.blade.php
@@ -26,4 +26,44 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('organizacionpesquera.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
+
+@if(isset($organizacion))
+    <hr>
+    <div class="mt-4">
+        <div class="d-flex justify-content-between mb-3">
+            <h4>Responsables</h4>
+            <a href="{{ route('asignacionresponsable.create') }}?organizacion_pesquera_id={{ $organizacion['id'] }}" class="btn btn-primary btn-sm">Nueva</a>
+        </div>
+        <table class="table table-dark table-striped">
+            <thead>
+                <tr>
+                    <th>Responsable</th>
+                    <th>Inicio</th>
+                    <th>Fin</th>
+                    <th>Estado</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($asignaciones ?? [] as $asignacion)
+                <tr>
+                    <td>{{ ($asignacion['nombres'] ?? '') . ' ' . ($asignacion['apellidos'] ?? '') }}</td>
+                    <td>{{ $asignacion['fecha_inicio'] ?? '' }}</td>
+                    <td>{{ $asignacion['fecha_fin'] ?? '' }}</td>
+                    <td>{{ $asignacion['estado'] ?? '' }}</td>
+                    <td class="text-right">
+                        <a href="{{ route('asignacionresponsable.edit', $asignacion['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                        <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    </div>
+@endif
+
 @endsection


### PR DESCRIPTION
## Summary
- fetch responsables for an organization on edit
- allow passing `organizacion_pesquera_id` to create responsable
- preselect organization when creating responsable
- display related responsables table on the organization edit screen
- handle unexpected API responses for asignacion editing

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886bc78a8448333ae33769068f6fb23