### PR TITLE
Improve Asignar Responsable CRUD

### DIFF
--- a/resources/views/asignacionresponsable/form.blade.php
+++ b/resources/views/asignacionresponsable/form.blade.php
@@ -45,6 +45,10 @@
         <div class="alert alert-danger">{{ $errors->first() }}</div>
     @endif
     <button type="submit" class="btn btn-primary">Guardar</button>
-    <a href="{{ route('asignacionresponsable.index') }}" class="btn btn-secondary">Cancelar</a>
+    @if($organizacionId)
+        <a href="{{ route('asignacionresponsable.index', ['organizacion_pesquera_id' => $organizacionId]) }}" class="btn btn-secondary">Cancelar</a>
+    @else
+        <a href="{{ route('asignacionresponsable.index') }}" class="btn btn-secondary">Cancelar</a>
+    @endif
 </form>
 @endsection

--- a/resources/views/asignacionresponsable/index.blade.php
+++ b/resources/views/asignacionresponsable/index.blade.php
@@ -2,8 +2,8 @@
 
 @section('content')
 <div class="d-flex justify-content-between mb-3">
-    <h3>Asignaciones de Responsable</h3>
-    <a href="{{ route('asignacionresponsable.create') }}" class="btn btn-primary">Nueva</a>
+    <h3>Asignaciones de Responsable @if($organizacion) de {{ $organizacion['nombre'] ?? '' }} @endif</h3>
+    <a href="{{ route('asignacionresponsable.create', $organizacionId ? ['organizacion_pesquera_id' => $organizacionId] : []) }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
@@ -32,7 +32,7 @@
             <td>{{ $asignacion['estado'] ?? '' }}</td>
             <td class="text-right">
                 <a href="{{ route('asignacionresponsable.edit', $asignacion['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
-                <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}{{ $organizacionId ? '?organizacion_pesquera_id='.$organizacionId : '' }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
                     @csrf
                     @method('DELETE')
                     <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
@@ -42,4 +42,7 @@
     @endforeach
     </tbody>
 </table>
+@if($organizacionId)
+    <a href="{{ route('organizacionpesquera.index') }}" class="btn btn-secondary mt-2">Volver a Organizaciones</a>
+@endif
 @endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -173,11 +173,22 @@
                             <p>Personas</p>
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a href="{{ route('asignacionresponsable.index') }}" class="nav-link">
+                    <li class="nav-item has-treeview">
+                        <a href="#" class="nav-link">
                             <i class="nav-icon fas fa-user-tie"></i>
-                            <p>Asignar Responsable</p>
+                            <p>
+                                Asignar responsable
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
                         </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('asignacionresponsable.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Asignar Responsable</p>
+                                </a>
+                            </li>
+                        </ul>
                     </li>
                     <li class="nav-item has-treeview">
                         <a href="#" class="nav-link">

--- a/resources/views/organizacionpesquera/form.blade.php
+++ b/resources/views/organizacionpesquera/form.blade.php
@@ -52,8 +52,8 @@
                     <td>{{ $asignacion['fecha_fin'] ?? '' }}</td>
                     <td>{{ $asignacion['estado'] ?? '' }}</td>
                     <td class="text-right">
-                        <a href="{{ route('asignacionresponsable.edit', $asignacion['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
-                        <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                        <a href="{{ route('asignacionresponsable.edit', $asignacion['id']) }}?organizacion_pesquera_id={{ $organizacion['id'] }}" class="btn btn-sm btn-secondary">Editar</a>
+                        <form action="{{ route('asignacionresponsable.destroy', $asignacion['id']) }}?organizacion_pesquera_id={{ $organizacion['id'] }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>


### PR DESCRIPTION
## Summary
- handle optional organization in AsignacionResponsableController
- show selected organization when listing or editing assignments
- update Cancel links and delete forms for context
- add back button for organization in assignment index
- nest "Asignar Responsable" under a treeview menu item

## Testing
- `composer install`
- `npm install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6886cf6365e8833394640bfeaa63054b