### PR TITLE
Show embarcaciones per type and update sidebar

### DIFF
--- a/app/Http/Controllers/TipoEmbarcacionController.php
+++ b/app/Http/Controllers/TipoEmbarcacionController.php
@@ -48,8 +48,12 @@ class TipoEmbarcacionController extends Controller
             abort(404);
         }
         $tipo = $response->json();
+        $embarcacionesResponse = $this->apiService->get("/embarcaciones/tipo/{$id}");
+        $embarcaciones = $embarcacionesResponse->successful() ? $embarcacionesResponse->json() : [];
+
         return view('tipoembarcacion.form', [
             'tipoembarcacion' => $tipo,
+            'embarcaciones' => $embarcaciones,
         ]);
     }
 

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -48,12 +48,6 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a href="{{ route('embarcaciones.index') }}" class="nav-link">
-                            <i class="nav-icon fas fa-ship"></i>
-                            <p>Embarcaciones</p>
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <a href="{{ route('campanias.index') }}" class="nav-link">
                             <i class="nav-icon fas fa-bullhorn"></i>
                             <p>Campañas</p>
@@ -125,11 +119,28 @@
                             <p>Tipos de Motor</p>
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a href="{{ route('tipoembarcaciones.index') }}" class="nav-link">
+                    <li class="nav-item has-treeview">
+                        <a href="#" class="nav-link">
                             <i class="nav-icon fas fa-ship"></i>
-                            <p>Tipos de Embarcación</p>
+                            <p>
+                                Tipos de Embarcación
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
                         </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('tipoembarcaciones.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Tipos de Embarcación</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('embarcaciones.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Embarcaciones</p>
+                                </a>
+                            </li>
+                        </ul>
                     </li>
                     <li class="nav-item">
                         <a href="{{ route('tipoobservador.index') }}" class="nav-link">

--- a/resources/views/tipoembarcacion/form.blade.php
+++ b/resources/views/tipoembarcacion/form.blade.php
@@ -17,4 +17,45 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('tipoembarcaciones.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
+
+@isset($tipoembarcacion)
+    <hr>
+    <div class="d-flex justify-content-between mb-2">
+        <h4>Embarcaciones</h4>
+        <a href="{{ route('embarcaciones.create') }}" class="btn btn-sm btn-primary">Nueva</a>
+    </div>
+    <table class="table table-dark table-striped">
+        <thead>
+            <tr>
+                <th>Código</th>
+                <th>Nombre</th>
+                <th>Matrícula</th>
+                <th>Eslora</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @forelse($embarcaciones ?? [] as $emb)
+            <tr>
+                <td>{{ $emb['codigo'] ?? '' }}</td>
+                <td>{{ $emb['nombre'] ?? '' }}</td>
+                <td>{{ $emb['matricula'] ?? '' }}</td>
+                <td>{{ $emb['eslora'] ?? '' }}</td>
+                <td class="text-right">
+                    <a href="{{ route('embarcaciones.edit', $emb['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                    <form action="{{ route('embarcaciones.destroy', $emb['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                    </form>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="5" class="text-center">Sin embarcaciones registradas</td>
+            </tr>
+        @endforelse
+        </tbody>
+    </table>
+@endisset
 @endsection


### PR DESCRIPTION
## Summary
- nest `Embarcaciones` under `Tipos de Embarcación` in the sidebar
- load the embarcaciones for a type when editing
- show a table of related embarcaciones in the edit view

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6886ebc5e7c883339f827b3b56667a69