### PR TITLE
Add role and menu configuration views

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class MenuController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/menus');
+        $menus = $response->successful() ? $response->json() : [];
+        return view('menus.index', [
+            'menus' => $menus,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('menus.form', [
+            'menus' => $this->getMenus(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'url' => ['nullable', 'string'],
+            'opcion' => ['required', 'string'],
+            'nivel' => ['nullable', 'string'],
+            'icono' => ['nullable', 'string'],
+            'url2' => ['nullable', 'string'],
+            'icono2' => ['nullable', 'string'],
+            'idmenupadre' => ['nullable', 'integer'],
+            'activo' => ['nullable', 'boolean'],
+        ]);
+
+        $response = $this->apiService->post('/menus', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('menus.index')->with('success', 'Menú creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/menus/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $menu = $response->json();
+        return view('menus.form', [
+            'menu' => $menu,
+            'menus' => $this->getMenus(),
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'url' => ['nullable', 'string'],
+            'opcion' => ['required', 'string'],
+            'nivel' => ['nullable', 'string'],
+            'icono' => ['nullable', 'string'],
+            'url2' => ['nullable', 'string'],
+            'icono2' => ['nullable', 'string'],
+            'idmenupadre' => ['nullable', 'integer'],
+            'activo' => ['nullable', 'boolean'],
+        ]);
+
+        $response = $this->apiService->put("/menus/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('menus.index')->with('success', 'Menú actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/menus/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('menus.index')->with('success', 'Menú eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getMenus(): array
+    {
+        $response = $this->apiService->get('/menus');
+        return $response->successful() ? $response->json() : [];
+    }
+}

--- a/app/Http/Controllers/RolController.php
+++ b/app/Http/Controllers/RolController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class RolController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/roles');
+        $roles = $response->successful() ? $response->json() : [];
+        return view('roles.index', [
+            'roles' => $roles,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('roles.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombrerol' => ['required', 'string'],
+            'codigo' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->post('/roles', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('roles.index')->with('success', 'Rol creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/roles/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $rol = $response->json();
+        return view('roles.form', [
+            'rol' => $rol,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombrerol' => ['required', 'string'],
+            'codigo' => ['required', 'string'],
+        ]);
+
+        $response = $this->apiService->put("/roles/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('roles.index')->with('success', 'Rol actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/roles/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('roles.index')->with('success', 'Rol eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}

--- a/app/Http/Controllers/RolMenuController.php
+++ b/app/Http/Controllers/RolMenuController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class RolMenuController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index()
+    {
+        $response = $this->apiService->get('/rolmenu');
+        $items = $response->successful() ? $response->json() : [];
+        return view('rolmenu.index', [
+            'items' => $items,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('rolmenu.form', [
+            'roles' => $this->getRoles(),
+            'menus' => $this->getMenus(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'idrol' => ['required', 'integer'],
+            'idmenu' => ['required', 'integer'],
+            'acceso' => ['required', 'integer'],
+        ]);
+
+        $response = $this->apiService->post('/rolmenu', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('rolmenu.index')->with('success', 'Asignación creada');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(int $idrol, int $idmenu)
+    {
+        $response = $this->apiService->get("/rolmenu/{$idrol}/{$idmenu}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $item = $response->json();
+        return view('rolmenu.form', [
+            'item' => $item,
+            'roles' => $this->getRoles(),
+            'menus' => $this->getMenus(),
+        ]);
+    }
+
+    public function update(Request $request, int $idrol, int $idmenu)
+    {
+        $data = $request->validate([
+            'acceso' => ['required', 'integer'],
+        ]);
+
+        $response = $this->apiService->put("/rolmenu/{$idrol}/{$idmenu}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('rolmenu.index')->with('success', 'Asignación actualizada');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(int $idrol, int $idmenu)
+    {
+        $response = $this->apiService->delete("/rolmenu/{$idrol}/{$idmenu}");
+
+        if ($response->successful()) {
+            return redirect()->route('rolmenu.index')->with('success', 'Asignación eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getRoles(): array
+    {
+        $response = $this->apiService->get('/roles');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getMenus(): array
+    {
+        $response = $this->apiService->get('/menus');
+        return $response->successful() ? $response->json() : [];
+    }
+}

--- a/app/Http/Controllers/RolPersonaController.php
+++ b/app/Http/Controllers/RolPersonaController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class RolPersonaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $personaId = $request->query('persona_id');
+        $roles = [];
+        $persona = null;
+        if ($personaId) {
+            $resp = $this->apiService->get("/rolpersona/{$personaId}");
+            $roles = $resp->successful() ? $resp->json() : [];
+            $persona = $this->getPersona($personaId);
+        }
+        return view('rolpersona.index', [
+            'roles' => $roles,
+            'personas' => $this->getPersonas(),
+            'personaId' => $personaId,
+            'persona' => $persona,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        $personaId = $request->query('persona_id');
+        return view('rolpersona.form', [
+            'roles' => $this->getRoles(),
+            'personas' => $this->getPersonas(),
+            'personaId' => $personaId,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'idpersona' => ['required', 'integer'],
+            'idrol' => ['required', 'integer'],
+        ]);
+
+        $response = $this->apiService->post('/rolpersona', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('rolpersona.index', ['persona_id' => $data['idpersona']])->with('success', 'Asignación creada');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function destroy(int $idpersona, int $idrol)
+    {
+        $response = $this->apiService->delete("/rolpersona/{$idpersona}/{$idrol}");
+
+        if ($response->successful()) {
+            return redirect()->route('rolpersona.index', ['persona_id' => $idpersona])->with('success', 'Asignación eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getRoles(): array
+    {
+        $response = $this->apiService->get('/roles');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getPersonas(): array
+    {
+        $response = $this->apiService->get('/personas');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getPersona(int $id)
+    {
+        $resp = $this->apiService->get("/personas/{$id}");
+        return $resp->successful() ? $resp->json() : null;
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -230,6 +230,41 @@
                             </li>
                         </ul>
                     </li>
+                    <li class="nav-item has-treeview">
+                        <a href="#" class="nav-link">
+                            <i class="nav-icon fas fa-cogs"></i>
+                            <p>
+                                Configuraci&oacute;n
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
+                        </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('roles.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Roles</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('menus.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Men&uacute;s</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('rolmenu.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Men&uacute;s por Rol</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('rolpersona.index') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Roles por Persona</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/resources/views/menus/form.blade.php
+++ b/resources/views/menus/form.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($menu) ? 'Editar' : 'Nuevo' }} Menú</h3>
+<form method="POST" action="{{ isset($menu) ? route('menus.update', $menu['id']) : route('menus.store') }}">
+    @csrf
+    @if(isset($menu))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Opción</label>
+        <input type="text" name="opcion" class="form-control" value="{{ old('opcion', $menu['opcion'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">URL</label>
+        <input type="text" name="url" class="form-control" value="{{ old('url', $menu['url'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Nivel</label>
+        <input type="text" name="nivel" class="form-control" value="{{ old('nivel', $menu['nivel'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Icono</label>
+        <input type="text" name="icono" class="form-control" value="{{ old('icono', $menu['icono'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">URL 2</label>
+        <input type="text" name="url2" class="form-control" value="{{ old('url2', $menu['url2'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Icono 2</label>
+        <input type="text" name="icono2" class="form-control" value="{{ old('icono2', $menu['icono2'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Menú Padre</label>
+        <select name="idmenupadre" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($menus as $m)
+                <option value="{{ $m['id'] }}" @selected(old('idmenupadre', $menu['idmenupadre'] ?? '') == $m['id'])>{{ $m['opcion'] ?? $m['id'] }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3 form-check">
+        <input type="hidden" name="activo" value="0">
+        <input type="checkbox" name="activo" value="1" class="form-check-input" id="activo" {{ old('activo', $menu['activo'] ?? true) ? 'checked' : '' }}>
+        <label class="form-check-label" for="activo">Activo</label>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('menus.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Menús</h3>
+    <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Opción</th>
+            <th>Nivel</th>
+            <th>Padre</th>
+            <th>Activo</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($menus as $menu)
+        <tr>
+            <td>{{ $menu['opcion'] ?? '' }}</td>
+            <td>{{ $menu['nivel'] ?? '' }}</td>
+            <td>{{ $menu['idmenupadre'] ?? '' }}</td>
+            <td>{{ isset($menu['activo']) && $menu['activo'] ? 'Sí' : 'No' }}</td>
+            <td class="text-right">
+                <a href="{{ route('menus.edit', $menu['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('menus.destroy', $menu['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/roles/form.blade.php
+++ b/resources/views/roles/form.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($rol) ? 'Editar' : 'Nuevo' }} Rol</h3>
+<form method="POST" action="{{ isset($rol) ? route('roles.update', $rol['id']) : route('roles.store') }}">
+    @csrf
+    @if(isset($rol))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombrerol" class="form-control" value="{{ old('nombrerol', $rol['nombrerol'] ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Código</label>
+        <input type="text" name="codigo" class="form-control" value="{{ old('codigo', $rol['codigo'] ?? '') }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('roles.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/roles/index.blade.php
+++ b/resources/views/roles/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Roles</h3>
+    <a href="{{ route('roles.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nombre</th>
+            <th>Código</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($roles as $rol)
+        <tr>
+            <td>{{ $rol['nombrerol'] ?? '' }}</td>
+            <td>{{ $rol['codigo'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('roles.edit', $rol['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('roles.destroy', $rol['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/rolmenu/form.blade.php
+++ b/resources/views/rolmenu/form.blade.php
@@ -1,0 +1,44 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($item) ? 'Editar' : 'Nueva' }} Asignación Menú a Rol</h3>
+<form method="POST" action="{{ isset($item) ? route('rolmenu.update', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) : route('rolmenu.store') }}">
+    @csrf
+    @if(isset($item))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Rol</label>
+        <select name="idrol" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
+            <option value="">Seleccione...</option>
+            @foreach($roles as $rol)
+                <option value="{{ $rol['id'] }}" @selected(old('idrol', $item['idrol'] ?? $rolMenuId ?? '') == $rol['id'])>{{ $rol['nombrerol'] ?? $rol['id'] }}</option>
+            @endforeach
+        </select>
+        @if(isset($item))
+            <input type="hidden" name="idrol" value="{{ $item['idrol'] }}">
+        @endif
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Menú</label>
+        <select name="idmenu" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
+            <option value="">Seleccione...</option>
+            @foreach($menus as $m)
+                <option value="{{ $m['id'] }}" @selected(old('idmenu', $item['idmenu'] ?? '') == $m['id'])>{{ $m['opcion'] ?? $m['id'] }}</option>
+            @endforeach
+        </select>
+        @if(isset($item))
+            <input type="hidden" name="idmenu" value="{{ $item['idmenu'] }}">
+        @endif
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Acceso</label>
+        <input type="number" name="acceso" class="form-control" value="{{ old('acceso', $item['acceso'] ?? 0) }}" required>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('rolmenu.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/rolmenu/index.blade.php
+++ b/resources/views/rolmenu/index.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Menús por Rol</h3>
+    <a href="{{ route('rolmenu.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Rol</th>
+            <th>Menú</th>
+            <th>Acceso</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($items as $item)
+        <tr>
+            <td>{{ $item['nombre_rol'] ?? $item['idrol'] }}</td>
+            <td>{{ $item['opcion_menu'] ?? $item['idmenu'] }}</td>
+            <td>{{ $item['acceso'] }}</td>
+            <td class="text-right">
+                <a href="{{ route('rolmenu.edit', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('rolmenu.destroy', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/rolpersona/form.blade.php
+++ b/resources/views/rolpersona/form.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>Asignar Rol a Persona</h3>
+<form method="POST" action="{{ route('rolpersona.store') }}">
+    @csrf
+    <div class="mb-3">
+        <label class="form-label">Persona</label>
+        <select name="idpersona" class="form-control" required>
+            <option value="">Seleccione...</option>
+            @foreach($personas as $p)
+                <option value="{{ $p['idpersona'] }}" @selected(old('idpersona', $personaId ?? '') == $p['idpersona'])>{{ $p['nombres'] ?? '' }} {{ $p['apellidos'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Rol</label>
+        <select name="idrol" class="form-control" required>
+            <option value="">Seleccione...</option>
+            @foreach($roles as $r)
+                <option value="{{ $r['id'] }}" @selected(old('idrol') == $r['id'])>{{ $r['nombrerol'] ?? $r['id'] }}</option>
+            @endforeach
+        </select>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('rolpersona.index', $personaId ? ['persona_id' => $personaId] : []) }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/rolpersona/index.blade.php
+++ b/resources/views/rolpersona/index.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Roles por Persona @if($persona) de {{ $persona['nombres'] ?? '' }} {{ $persona['apellidos'] ?? '' }} @endif</h3>
+    <a href="{{ route('rolpersona.create', $personaId ? ['persona_id' => $personaId] : []) }}" class="btn btn-primary">Nuevo</a>
+</div>
+<form method="GET" action="{{ route('rolpersona.index') }}" class="mb-3">
+    <div class="input-group">
+        <select name="persona_id" class="form-control">
+            <option value="">Seleccione Persona...</option>
+            @foreach($personas as $p)
+                <option value="{{ $p['idpersona'] }}" @selected($personaId == $p['idpersona'])>{{ $p['nombres'] ?? '' }} {{ $p['apellidos'] ?? '' }}</option>
+            @endforeach
+        </select>
+        <div class="input-group-append">
+            <button class="btn btn-secondary">Ver</button>
+        </div>
+    </div>
+</form>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Rol</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($roles as $r)
+        <tr>
+            <td>{{ $r['nombre_rol'] ?? $r['idrol'] }}</td>
+            <td class="text-right">
+                <form action="{{ route('rolpersona.destroy', ['idpersona' => $r['idpersona'], 'idrol' => $r['idrol']]) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,10 @@ use App\Http\Controllers\FamiliaController;
 use App\Http\Controllers\EspecieController;
 use App\Http\Controllers\OrganizacionPesqueraController;
 use App\Http\Controllers\AsignacionResponsableController;
+use App\Http\Controllers\MenuController;
+use App\Http\Controllers\RolController;
+use App\Http\Controllers\RolMenuController;
+use App\Http\Controllers\RolPersonaController;
 
 Route::get('/', function () {
     return view('home');
@@ -62,4 +66,14 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('especies', EspecieController::class)->except(['show']);
     Route::resource('organizacionpesquera', OrganizacionPesqueraController::class)->except(['show']);
     Route::resource('asignacionresponsable', AsignacionResponsableController::class)->except(['show']);
+
+    Route::resource('menus', MenuController::class)->except(['show']);
+    Route::resource('roles', RolController::class)->except(['show']);
+    Route::get('rolmenu/{idrol}/{idmenu}/edit', [RolMenuController::class, 'edit'])->name('rolmenu.edit');
+    Route::put('rolmenu/{idrol}/{idmenu}', [RolMenuController::class, 'update'])->name('rolmenu.update');
+    Route::delete('rolmenu/{idrol}/{idmenu}', [RolMenuController::class, 'destroy'])->name('rolmenu.destroy');
+    Route::resource('rolmenu', RolMenuController::class)->only(['index', 'create', 'store']);
+
+    Route::delete('rolpersona/{idpersona}/{idrol}', [RolPersonaController::class, 'destroy'])->name('rolpersona.destroy');
+    Route::resource('rolpersona', RolPersonaController::class)->only(['index', 'create', 'store']);
 });


### PR DESCRIPTION
## Summary
- create controllers for menu, role, role menu and role persona management
- provide blade views for CRUD screens
- register new routes
- show Configuración section in dashboard

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6886fd7684208333a0442a17a1430890