### PR TITLE
Implement Viaje CRUD

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class ViajeController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $fechaInicio = $request->query('fecha_inicio', now()->startOfMonth()->format('Y-m-d'));
+        $fechaFin = $request->query('fecha_fin', now()->format('Y-m-d'));
+
+        $response = $this->apiService->get('/viajes', [
+            'fecha_inicio' => $fechaInicio,
+            'fecha_fin' => $fechaFin,
+        ]);
+        $viajes = $response->successful() ? $response->json() : [];
+
+        return view('viajes.index', [
+            'viajes' => $viajes,
+            'fechaInicio' => $fechaInicio,
+            'fechaFin' => $fechaFin,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('viajes.form', [
+            'muelles' => $this->getMuelles(),
+            'puertos' => $this->getPuertos(),
+            'embarcaciones' => $this->getEmbarcaciones(),
+            'campanias' => $this->getCampanias(),
+            'responsables' => $this->getPersonasPorRol('RESPVJ'),
+            'digitadores' => $this->getPersonasPorRol('CTF'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'fecha_zarpe' => ['nullable', 'date'],
+            'hora_zarpe' => ['nullable'],
+            'fecha_arribo' => ['nullable', 'date'],
+            'hora_arribo' => ['nullable'],
+            'observaciones' => ['nullable', 'string'],
+            'muelle_id' => ['nullable', 'integer'],
+            'puerto_zarpe_id' => ['nullable', 'integer'],
+            'puerto_arribo_id' => ['nullable', 'integer'],
+            'persona_idpersona' => ['nullable', 'integer'],
+            'embarcacion_id' => ['nullable', 'integer'],
+            'digitador_id' => ['nullable', 'integer'],
+            'campania_id' => ['nullable', 'integer'],
+        ]);
+
+        $response = $this->apiService->post('/viajes', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('viajes.index')->with('success', 'Viaje creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $response = $this->apiService->get("/viajes/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+        $viaje = $response->json();
+
+        return view('viajes.form', [
+            'viaje' => $viaje,
+            'muelles' => $this->getMuelles(),
+            'puertos' => $this->getPuertos(),
+            'embarcaciones' => $this->getEmbarcaciones(),
+            'campanias' => $this->getCampanias(),
+            'responsables' => $this->getPersonasPorRol('RESPVJ'),
+            'digitadores' => $this->getPersonasPorRol('CTF'),
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'fecha_zarpe' => ['nullable', 'date'],
+            'hora_zarpe' => ['nullable'],
+            'fecha_arribo' => ['nullable', 'date'],
+            'hora_arribo' => ['nullable'],
+            'observaciones' => ['nullable', 'string'],
+            'muelle_id' => ['nullable', 'integer'],
+            'puerto_zarpe_id' => ['nullable', 'integer'],
+            'puerto_arribo_id' => ['nullable', 'integer'],
+            'persona_idpersona' => ['nullable', 'integer'],
+            'embarcacion_id' => ['nullable', 'integer'],
+            'digitador_id' => ['nullable', 'integer'],
+            'campania_id' => ['nullable', 'integer'],
+        ]);
+
+        $response = $this->apiService->put("/viajes/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('viajes.index')->with('success', 'Viaje actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(string $id)
+    {
+        $response = $this->apiService->delete("/viajes/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('viajes.index')->with('success', 'Viaje eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    private function getMuelles(): array
+    {
+        $response = $this->apiService->get('/muelles');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getPuertos(): array
+    {
+        $response = $this->apiService->get('/puertos');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getEmbarcaciones(): array
+    {
+        $response = $this->apiService->get('/embarcaciones');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getCampanias(): array
+    {
+        $response = $this->apiService->get('/campanias');
+        return $response->successful() ? $response->json() : [];
+    }
+
+    private function getPersonasPorRol(string $codigoRol): array
+    {
+        $response = $this->apiService->get("/buscar-personas/{$codigoRol}");
+        return $response->successful() ? $response->json() : [];
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -54,6 +54,12 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="{{ route('viajes.index') }}" class="nav-link">
+                            <i class="nav-icon fas fa-route"></i>
+                            <p>Viajes</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a href="{{ route('puertos.index') }}" class="nav-link">
                             <i class="nav-icon fas fa-anchor"></i>
                             <p>Puertos</p>

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1,0 +1,99 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($viaje) ? 'Editar' : 'Nuevo' }} Viaje</h3>
+<form method="POST" action="{{ isset($viaje) ? route('viajes.update', $viaje['id']) : route('viajes.store') }}">
+    @csrf
+    @if(isset($viaje))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Fecha Zarpe</label>
+        <input type="date" name="fecha_zarpe" class="form-control" value="{{ old('fecha_zarpe', $viaje['fecha_zarpe'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Hora Zarpe</label>
+        <input type="time" name="hora_zarpe" class="form-control" value="{{ old('hora_zarpe', $viaje['hora_zarpe'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Fecha Arribo</label>
+        <input type="date" name="fecha_arribo" class="form-control" value="{{ old('fecha_arribo', $viaje['fecha_arribo'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Hora Arribo</label>
+        <input type="time" name="hora_arribo" class="form-control" value="{{ old('hora_arribo', $viaje['hora_arribo'] ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Observaciones</label>
+        <textarea name="observaciones" class="form-control">{{ old('observaciones', $viaje['observaciones'] ?? '') }}</textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Muelle</label>
+        <select name="muelle_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($muelles as $m)
+                <option value="{{ $m['id'] }}" @selected(old('muelle_id', $viaje['muelle_id'] ?? '') == $m['id'])>{{ $m['nombre'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Puerto Zarpe</label>
+        <select name="puerto_zarpe_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($puertos as $p)
+                <option value="{{ $p['id'] }}" @selected(old('puerto_zarpe_id', $viaje['puerto_zarpe_id'] ?? '') == $p['id'])>{{ $p['nombre'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Puerto Arribo</label>
+        <select name="puerto_arribo_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($puertos as $p)
+                <option value="{{ $p['id'] }}" @selected(old('puerto_arribo_id', $viaje['puerto_arribo_id'] ?? '') == $p['id'])>{{ $p['nombre'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Responsable</label>
+        <select name="persona_idpersona" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($responsables as $per)
+                <option value="{{ $per['idpersona'] }}" @selected(old('persona_idpersona', $viaje['persona_idpersona'] ?? '') == $per['idpersona'])>{{ $per['nombres'] ?? '' }} {{ $per['apellidos'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Embarcación</label>
+        <select name="embarcacion_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($embarcaciones as $e)
+                <option value="{{ $e['id'] }}" @selected(old('embarcacion_id', $viaje['embarcacion_id'] ?? '') == $e['id'])>{{ $e['nombre'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Digitador</label>
+        <select name="digitador_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($digitadores as $d)
+                <option value="{{ $d['idpersona'] }}" @selected(old('digitador_id', $viaje['digitador_id'] ?? '') == $d['idpersona'])>{{ $d['nombres'] ?? '' }} {{ $d['apellidos'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Campaña</label>
+        <select name="campania_id" class="form-control">
+            <option value="">Seleccione...</option>
+            @foreach($campanias as $c)
+                <option value="{{ $c['id'] }}" @selected(old('campania_id', $viaje['campania_id'] ?? '') == $c['id'])>{{ $c['descripcion'] ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('viajes.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Viajes</h3>
+    <a href="{{ route('viajes.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+<form method="GET" action="{{ route('viajes.index') }}" class="mb-3">
+    <div class="form-row">
+        <div class="col">
+            <input type="date" name="fecha_inicio" class="form-control" value="{{ $fechaInicio }}">
+        </div>
+        <div class="col">
+            <input type="date" name="fecha_fin" class="form-control" value="{{ $fechaFin }}">
+        </div>
+        <div class="col-auto">
+            <button class="btn btn-secondary">Filtrar</button>
+        </div>
+    </div>
+</form>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Fecha Zarpe</th>
+            <th>Hora Zarpe</th>
+            <th>Fecha Arribo</th>
+            <th>Hora Arribo</th>
+            <th>Embarcación</th>
+            <th>Campaña</th>
+            <th>Responsable</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($viajes as $v)
+        <tr>
+            <td>{{ $v['fecha_zarpe'] ?? '' }}</td>
+            <td>{{ $v['hora_zarpe'] ?? '' }}</td>
+            <td>{{ $v['fecha_arribo'] ?? '' }}</td>
+            <td>{{ $v['hora_arribo'] ?? '' }}</td>
+            <td>{{ $v['embarcacion_nombre'] ?? '' }}</td>
+            <td>{{ $v['campania_descripcion'] ?? '' }}</td>
+            <td>{{ ($v['pescador_nombres'] ?? '') . ' ' . ($v['pescador_apellidos'] ?? '') }}</td>
+            <td class="text-right">
+                <a href="{{ route('viajes.edit', $v['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('viajes.destroy', $v['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\MenuController;
 use App\Http\Controllers\RolController;
 use App\Http\Controllers\RolMenuController;
 use App\Http\Controllers\RolPersonaController;
+use App\Http\Controllers\ViajeController;
 
 Route::get('/', function () {
     return view('home');
@@ -66,6 +67,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('especies', EspecieController::class)->except(['show']);
     Route::resource('organizacionpesquera', OrganizacionPesqueraController::class)->except(['show']);
     Route::resource('asignacionresponsable', AsignacionResponsableController::class)->except(['show']);
+    Route::resource('viajes', ViajeController::class)->except(['show']);
 
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add ViajeController with CRUD operations using API endpoints
- create views for listing and editing Viajes
- register Viajes routes and add sidebar link

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68885ad1afb48333847322261109649c