### PR TITLE
Enable Select2 search on viaje form

### DIFF
--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -6,7 +6,8 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css">
     <link rel="stylesheet" href="{{ asset('css/dashboard.css') }}">
 </head>
 <body class="hold-transition sidebar-mini layout-fixed dark-mode">
@@ -287,5 +288,7 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+@yield('scripts')
 </body>
 </html>

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -56,7 +56,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Responsable</label>
-        <select name="persona_idpersona" class="form-control">
+        <select name="persona_idpersona" class="form-control select2">
             <option value="">Seleccione...</option>
             @foreach($responsables as $per)
                 <option value="{{ $per['idpersona'] }}" @selected(old('persona_idpersona', $viaje['persona_idpersona'] ?? '') == $per['idpersona'])>{{ $per['nombres'] ?? '' }} {{ $per['apellidos'] ?? '' }}</option>
@@ -74,7 +74,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Digitador</label>
-        <select name="digitador_id" class="form-control">
+        <select name="digitador_id" class="form-control select2">
             <option value="">Seleccione...</option>
             @foreach($digitadores as $d)
                 <option value="{{ $d['idpersona'] }}" @selected(old('digitador_id', $viaje['digitador_id'] ?? '') == $d['idpersona'])>{{ $d['nombres'] ?? '' }} {{ $d['apellidos'] ?? '' }}</option>
@@ -96,4 +96,12 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('viajes.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
+@endsection
+
+@section('scripts')
+<script>
+    $(document).ready(function() {
+        $('.select2').select2({width: '100%'});
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- add select2 assets to dashboard layout
- convert responsable and digitador fields to Select2
- initialize Select2 in viaje form

## Testing
- `composer install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6888639e4c4c83338c8000da92d8f8dd