### PR TITLE
Enable AJAX Select2 search in viaje form

### DIFF
--- a/app/Http/Controllers/PersonaController.php
+++ b/app/Http/Controllers/PersonaController.php
@@ -98,4 +98,21 @@ class PersonaController extends Controller
 
         return back()->withErrors(['error' => 'Error al eliminar']);
     }
+
+    public function buscarPorRol(Request $request)
+    {
+        $rol = $request->query('rol');
+        $filtro = $request->query('filtro');
+        if (! $rol) {
+            return response()->json([]);
+        }
+
+        $resp = $this->apiService->get("/buscar-personas/{$rol}", [
+            'filtro' => $filtro,
+        ]);
+
+        $data = $resp->successful() ? $resp->json() : [];
+
+        return response()->json($data);
+    }
 }

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -6,7 +6,8 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css">
     <link rel="stylesheet" href="{{ asset('css/dashboard.css') }}">
 </head>
 <body class="hold-transition sidebar-mini layout-fixed dark-mode">
@@ -287,5 +288,7 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+@yield('scripts')
 </body>
 </html>

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -56,7 +56,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Responsable</label>
-        <select name="persona_idpersona" class="form-control">
+        <select id="responsable-select" name="persona_idpersona" class="form-control select2">
             <option value="">Seleccione...</option>
             @foreach($responsables as $per)
                 <option value="{{ $per['idpersona'] }}" @selected(old('persona_idpersona', $viaje['persona_idpersona'] ?? '') == $per['idpersona'])>{{ $per['nombres'] ?? '' }} {{ $per['apellidos'] ?? '' }}</option>
@@ -74,7 +74,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Digitador</label>
-        <select name="digitador_id" class="form-control">
+        <select id="digitador-select" name="digitador_id" class="form-control select2">
             <option value="">Seleccione...</option>
             @foreach($digitadores as $d)
                 <option value="{{ $d['idpersona'] }}" @selected(old('digitador_id', $viaje['digitador_id'] ?? '') == $d['idpersona'])>{{ $d['nombres'] ?? '' }} {{ $d['apellidos'] ?? '' }}</option>
@@ -96,4 +96,38 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('viajes.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
+@endsection
+
+@section('scripts')
+<script>
+    $(function() {
+        $('#responsable-select').select2({
+            width: '100%',
+            ajax: {
+                url: "{{ route('ajax.personas') }}",
+                dataType: 'json',
+                delay: 250,
+                data: params => ({ filtro: params.term, rol: 'RESPVJ' }),
+                processResults: data => ({
+                    results: $.map(data, p => ({ id: p.idpersona, text: `${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim() }))
+                }),
+                cache: true
+            }
+        });
+
+        $('#digitador-select').select2({
+            width: '100%',
+            ajax: {
+                url: "{{ route('ajax.personas') }}",
+                dataType: 'json',
+                delay: 250,
+                data: params => ({ filtro: params.term, rol: 'CTF' }),
+                processResults: data => ({
+                    results: $.map(data, p => ({ id: p.idpersona, text: `${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim() }))
+                }),
+                cache: true
+            }
+        });
+    });
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('estadosmarea', EstadoMareaController::class)->except(['show']);
     Route::resource('estadodesarrollogonadal', EstadoDesarrolloGonadalController::class)->except(['show']);
     Route::resource('personas', PersonaController::class)->except(['show']);
+    Route::get('ajax/personas', [PersonaController::class, 'buscarPorRol'])->name('ajax.personas');
     Route::resource('familias', FamiliaController::class)->except(['show']);
     Route::resource('especies', EspecieController::class)->except(['show']);
     Route::resource('organizacionpesquera', OrganizacionPesqueraController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add AJAX search method in PersonaController
- expose `/ajax/personas` endpoint for searching personas by role
- initialize Select2 with AJAX for responsable and digitador fields

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6888639e4c4c83338c8000da92d8f8dd