### PR TITLE
Add pending trips page

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -180,6 +180,45 @@ class ViajeController extends Controller
             ->withInput();
     }
 
+    public function pendientes()
+    {
+        $response = $this->apiService->get('/viajes/pendientes');
+        $viajes = $response->successful() ? $response->json() : [];
+
+        return view('viajes.pendientes', [
+            'viajes' => $viajes,
+        ]);
+    }
+
+    public function mostrar(string $id)
+    {
+        $response = $this->apiService->get("/viajes/{$id}");
+        if (! $response->successful()) {
+            abort(404);
+        }
+
+        return view('viajes.mostrar', [
+            'viaje' => $response->json(),
+        ]);
+    }
+
+    public function seleccionar(string $id)
+    {
+        $digitadorId = session('user.idpersona');
+
+        $response = $this->apiService->post(
+            "/viajes/{$id}/seleccionar?viaje_id={$id}&digitador_id={$digitadorId}"
+        );
+
+        if ($response->successful()) {
+            return redirect()
+                ->route('viajes.pendientes')
+                ->with('success', 'Viaje asignado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al seleccionar el viaje']);
+    }
+
     private function getMuelles(): array
     {
         $response = $this->apiService->get('/muelles');

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -70,6 +70,12 @@
                                 </a>
                             </li>
                             <li class="nav-item">
+                                <a href="{{ route('viajes.pendientes') }}" class="nav-link">
+                                    <i class="far fa-circle nav-icon"></i>
+                                    <p>Viajes pendientes</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
                                 <a href="{{ route('viajes.mis-por-finalizar') }}" class="nav-link">
                                     <i class="far fa-circle nav-icon"></i>
                                     <p>Mis viajes por finalizar</p>

--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Detalle del viaje</h3>
+    </div>
+    <div class="card-body">
+        <dl class="row">
+            <dt class="col-sm-4">Fecha Zarpe</dt>
+            <dd class="col-sm-8">{{ $viaje['fecha_zarpe'] ?? '' }} {{ $viaje['hora_zarpe'] ?? '' }}</dd>
+            <dt class="col-sm-4">Fecha Arribo</dt>
+            <dd class="col-sm-8">{{ $viaje['fecha_arribo'] ?? '' }} {{ $viaje['hora_arribo'] ?? '' }}</dd>
+            <dt class="col-sm-4">Embarcación</dt>
+            <dd class="col-sm-8">{{ $viaje['embarcacion_nombre'] ?? '' }}</dd>
+            <dt class="col-sm-4">Campaña</dt>
+            <dd class="col-sm-8">{{ $viaje['campania_descripcion'] ?? '' }}</dd>
+            <dt class="col-sm-4">Responsable</dt>
+            <dd class="col-sm-8">{{ ($viaje['pescador_nombres'] ?? '') . ' ' . ($viaje['pescador_apellidos'] ?? '') }}</dd>
+            <dt class="col-sm-4">Observaciones</dt>
+            <dd class="col-sm-8">{{ $viaje['observaciones'] ?? '' }}</dd>
+        </dl>
+    </div>
+    <div class="card-footer">
+        <a href="{{ route('viajes.pendientes') }}" class="btn btn-secondary">Volver</a>
+    </div>
+</div>
+@endsection

--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="card-title mb-0">Viajes pendientes</h3>
+    </div>
+    <div class="card-body">
+        @if(session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+        @if($errors->any())
+            <div class="alert alert-danger">{{ $errors->first() }}</div>
+        @endif
+        <div class="table-responsive">
+            <table class="table table-dark table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th>Fecha Zarpe</th>
+                        <th>Hora Zarpe</th>
+                        <th>Fecha Arribo</th>
+                        <th>Hora Arribo</th>
+                        <th>Embarcación</th>
+                        <th>Campaña</th>
+                        <th>Responsable</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach($viajes as $v)
+                    <tr>
+                        <td>{{ $v['fecha_zarpe'] ?? '' }}</td>
+                        <td>{{ $v['hora_zarpe'] ?? '' }}</td>
+                        <td>{{ $v['fecha_arribo'] ?? '' }}</td>
+                        <td>{{ $v['hora_arribo'] ?? '' }}</td>
+                        <td>{{ $v['embarcacion_nombre'] ?? '' }}</td>
+                        <td>{{ $v['campania_descripcion'] ?? '' }}</td>
+                        <td>{{ ($v['pescador_nombres'] ?? '') . ' ' . ($v['pescador_apellidos'] ?? '') }}</td>
+                        <td class="text-right">
+                            <a href="{{ route('viajes.mostrar', $v['id']) }}" class="btn btn-sm btn-info">Mostrar</a>
+                            <form method="POST" action="{{ route('viajes.seleccionar', $v['id']) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-sm btn-primary">Seleccionar</button>
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,9 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('asignacionresponsable', AsignacionResponsableController::class)->except(['show']);
     Route::get('mis-viajes-por-finalizar', [ViajeController::class, 'misPorFinalizar'])->name('viajes.mis-por-finalizar');
     Route::put('viajes/{viaje}/por-finalizar', [ViajeController::class, 'updatePorFinalizar'])->name('viajes.por-finalizar.update');
+    Route::get('viajes/pendientes', [ViajeController::class, 'pendientes'])->name('viajes.pendientes');
+    Route::get('viajes/{viaje}/mostrar', [ViajeController::class, 'mostrar'])->name('viajes.mostrar');
+    Route::post('viajes/{viaje}/seleccionar', [ViajeController::class, 'seleccionar'])->name('viajes.seleccionar');
     Route::resource('viajes', ViajeController::class)->except(['show']);
 
     Route::resource('menus', MenuController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add controller methods for pending trips and selection
- wire routes for pending trips
- list pending trips in a new view
- add detail page for viewing trip info
- link new page from sidebar

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688b03a16c9c8333bfe71bbd600c85e9