### PR TITLE
Mostrar IDs y selección predeterminada

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -125,7 +125,7 @@ class ViajeController extends Controller
 
     public function misPorFinalizar(Request $request)
     {
-        $digitadorId = $request->query('digitador_id');
+        $digitadorId = $request->query('digitador_id', session('user.idpersona'));
 
         $digitadores = $this->getPersonasPorRol('CTF');
 

--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -30,6 +30,7 @@
             <table class="table table-dark table-striped mb-0">
     <thead>
         <tr>
+            <th>ID</th>
             <th>Fecha Zarpe</th>
             <th>Hora Zarpe</th>
             <th>Fecha Arribo</th>
@@ -43,6 +44,7 @@
     <tbody>
     @foreach($viajes as $v)
         <tr>
+            <td>{{ $v['id'] ?? '' }}</td>
             <td>{{ $v['fecha_zarpe'] ?? '' }}</td>
             <td>{{ $v['hora_zarpe'] ?? '' }}</td>
             <td>{{ $v['fecha_arribo'] ?? '' }}</td>

--- a/resources/views/viajes/mis-por-finalizar.blade.php
+++ b/resources/views/viajes/mis-por-finalizar.blade.php
@@ -31,6 +31,7 @@
             <table class="table table-dark table-striped mb-0">
                 <thead>
                     <tr>
+                        <th>ID</th>
                         <th>Fecha Zarpe</th>
                         <th>Hora Zarpe</th>
                         <th>Fecha Arribo</th>
@@ -44,6 +45,7 @@
                 <tbody>
                 @foreach($viajes as $v)
                     <tr>
+                        <td>{{ $v['id'] ?? '' }}</td>
                         <td>{{ $v['fecha_zarpe'] ?? '' }}</td>
                         <td>{{ $v['hora_zarpe'] ?? '' }}</td>
                         <td>{{ $v['fecha_arribo'] ?? '' }}</td>

--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -16,6 +16,7 @@
             <table class="table table-dark table-striped mb-0">
                 <thead>
                     <tr>
+                        <th>ID</th>
                         <th>Fecha Zarpe</th>
                         <th>Hora Zarpe</th>
                         <th>Fecha Arribo</th>
@@ -29,6 +30,7 @@
                 <tbody>
                 @foreach($viajes as $v)
                     <tr>
+                        <td>{{ $v['id'] ?? '' }}</td>
                         <td>{{ $v['fecha_zarpe'] ?? '' }}</td>
                         <td>{{ $v['hora_zarpe'] ?? '' }}</td>
                         <td>{{ $v['fecha_arribo'] ?? '' }}</td>


### PR DESCRIPTION
## Summary
- display Viaje id column in all tables
- preselect logged-in user in "Mis viajes por finalizar"

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688ce7ae57988333bc15a87ffc01af55