### PR TITLE
Add Captura table to viaje edit page

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -132,6 +132,35 @@
             </div>
         </div>
     </form>
+
+    @isset($viaje)
+        @if(request()->boolean('por_finalizar'))
+            <div class="card mt-3">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h3 class="card-title mb-0">Capturas</h3>
+                    <button class="btn btn-tool" type="button" data-toggle="collapse" data-target="#capturas-collapse">
+                        <i class="fas fa-minus"></i>
+                    </button>
+                </div>
+                <div class="card-body collapse show" id="capturas-collapse">
+                    <div class="table-responsive">
+                        <table class="table table-dark table-striped mb-0" id="capturas-table">
+                            <thead>
+                                <tr>
+                                    <th>Nombre común</th>
+                                    <th>Nº Individuos</th>
+                                    <th>Peso Estimado</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                    <button type="button" class="btn btn-primary btn-sm mt-2" id="agregar-captura">Agregar</button>
+                </div>
+            </div>
+        @endif
+    @endisset
 @endsection
 
 @section('scripts')
@@ -168,6 +197,104 @@
                     cache: true
                 }
             });
+            const apiBase = 'http://186.46.31.211:9090';
+            const token = '{{ session('token') }}';
+            const viajeId = {{ $viaje['id'] ?? 'null' }};
+
+            function authHeaders() {
+                return token ? { Authorization: `Bearer ${token}` } : {};
+            }
+
+            function cargarCapturas() {
+                $.ajax({
+                    url: `${apiBase}/isospam/capturas-viaje`,
+                    data: { viaje_id: viajeId },
+                    headers: authHeaders(),
+                    success: data => {
+                        const tbody = $('#capturas-table tbody').empty();
+                        data.forEach(c => {
+                            const row = `<tr>
+                                <td>${c.nombre_comun ?? ''}</td>
+                                <td>${c.numero_individuos ?? ''}</td>
+                                <td>${c.peso_estimado ?? ''}</td>
+                                <td class="text-right">
+                                    <button class="btn btn-sm btn-secondary editar-captura" data-id="${c.id}">Editar</button>
+                                    <button class="btn btn-sm btn-danger eliminar-captura" data-id="${c.id}">Eliminar</button>
+                                </td>
+                            </tr>`;
+                            tbody.append(row);
+                        });
+                    }
+                });
+            }
+
+            function crearCaptura() {
+                const nombre = prompt('Nombre común');
+                if (nombre === null) return;
+                const num = prompt('Número de individuos');
+                const peso = prompt('Peso estimado');
+                $.ajax({
+                    url: `${apiBase}/isospam/capturas`,
+                    method: 'POST',
+                    headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders()),
+                    data: JSON.stringify({
+                        nombre_comun: nombre,
+                        numero_individuos: num,
+                        peso_estimado: peso,
+                        viaje_id: viajeId
+                    }),
+                    success: cargarCapturas
+                });
+            }
+
+            function editarCaptura(id) {
+                $.ajax({
+                    url: `${apiBase}/isospam/capturas/${id}`,
+                    headers: authHeaders(),
+                    success: data => {
+                        const nombre = prompt('Nombre común', data.nombre_comun);
+                        if (nombre === null) return;
+                        const num = prompt('Número de individuos', data.numero_individuos);
+                        const peso = prompt('Peso estimado', data.peso_estimado);
+                        $.ajax({
+                            url: `${apiBase}/isospam/capturas/${id}`,
+                            method: 'PUT',
+                            headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders()),
+                            data: JSON.stringify({
+                                nombre_comun: nombre,
+                                numero_individuos: num,
+                                peso_estimado: peso,
+                                peso_contado: data.peso_contado,
+                                especie_id: data.especie_id,
+                                viaje_id: viajeId,
+                                es_incidental: data.es_incidental,
+                                es_descartada: data.es_descartada,
+                                tipo_numero_individuos: data.tipo_numero_individuos,
+                                tipo_peso: data.tipo_peso,
+                                estado_producto: data.estado_producto
+                            }),
+                            success: cargarCapturas
+                        });
+                    }
+                });
+            }
+
+            function eliminarCaptura(id) {
+                if (!confirm('¿Eliminar captura?')) return;
+                $.ajax({
+                    url: `${apiBase}/isospam/capturas/${id}`,
+                    method: 'DELETE',
+                    headers: authHeaders(),
+                    success: cargarCapturas
+                });
+            }
+
+            if (viajeId && {{ request()->boolean('por_finalizar') ? 'true' : 'false' }}) {
+                cargarCapturas();
+                $('#agregar-captura').on('click', crearCaptura);
+                $('#capturas-table').on('click', '.editar-captura', function () { editarCaptura($(this).data('id')); });
+                $('#capturas-table').on('click', '.eliminar-captura', function () { eliminarCaptura($(this).data('id')); });
+            }
         });
     </script>
 @endsection


### PR DESCRIPTION
## Summary
- show collapsible Capturas table when editing a viaje from `por_finalizar`
- load capturas via API and allow basic CRUD operations with jQuery

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688d074dbdd483339c6fc5fa7c6baece