### PR TITLE
Use internal AJAX controller for captures

### DIFF
--- a/app/Http/Controllers/CapturaAjaxController.php
+++ b/app/Http/Controllers/CapturaAjaxController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class CapturaAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $resp = $this->apiService->get('/capturas-viaje', [
+            'viaje_id' => $request->query('viaje_id'),
+        ]);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function show(string $id)
+    {
+        $resp = $this->apiService->get("/capturas/{$id}");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nombre_comun' => ['nullable', 'string'],
+            'numero_individuos' => ['nullable', 'integer'],
+            'peso_estimado' => ['nullable', 'numeric'],
+            'peso_contado' => ['nullable', 'numeric'],
+            'especie_id' => ['nullable', 'integer'],
+            'viaje_id' => ['required', 'integer'],
+            'es_incidental' => ['nullable', 'boolean'],
+            'es_descartada' => ['nullable', 'boolean'],
+            'tipo_numero_individuos' => ['nullable', 'string'],
+            'tipo_peso' => ['nullable', 'string'],
+            'estado_producto' => ['nullable', 'string'],
+        ]);
+
+        $resp = $this->apiService->post('/capturas', $data);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'nombre_comun' => ['nullable', 'string'],
+            'numero_individuos' => ['nullable', 'integer'],
+            'peso_estimado' => ['nullable', 'numeric'],
+            'peso_contado' => ['nullable', 'numeric'],
+            'especie_id' => ['nullable', 'integer'],
+            'viaje_id' => ['required', 'integer'],
+            'es_incidental' => ['nullable', 'boolean'],
+            'es_descartada' => ['nullable', 'boolean'],
+            'tipo_numero_individuos' => ['nullable', 'string'],
+            'tipo_peso' => ['nullable', 'string'],
+            'estado_producto' => ['nullable', 'string'],
+        ]);
+
+        $resp = $this->apiService->put("/capturas/{$id}", $data);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function destroy(string $id)
+    {
+        $resp = $this->apiService->delete("/capturas/{$id}");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -214,19 +214,13 @@
                     cache: true
                 }
             });
-            const apiBase = 'http://186.46.31.211:9090';
-            const token = '{{ session('token') }}';
+            const ajaxBase = '{{ url('ajax') }}';
             const viajeId = {{ $viaje['id'] ?? 'null' }};
-
-            function authHeaders() {
-                return token ? { Authorization: `Bearer ${token}` } : {};
-            }
 
             function cargarCapturas() {
                 $.ajax({
-                    url: `${apiBase}/isospam/capturas-viaje`,
+                    url: `${ajaxBase}/capturas-viaje`,
                     data: { viaje_id: viajeId },
-                    headers: authHeaders(),
                     success: data => {
                         const tbody = $('#capturas-table tbody').empty();
                         data.forEach(c => {
@@ -251,9 +245,9 @@
                 const num = prompt('Número de individuos');
                 const peso = prompt('Peso estimado');
                 $.ajax({
-                    url: `${apiBase}/isospam/capturas`,
+                    url: `${ajaxBase}/capturas`,
                     method: 'POST',
-                    headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders()),
+                    contentType: 'application/json',
                     data: JSON.stringify({
                         nombre_comun: nombre,
                         numero_individuos: num,
@@ -266,17 +260,16 @@
 
             function editarCaptura(id) {
                 $.ajax({
-                    url: `${apiBase}/isospam/capturas/${id}`,
-                    headers: authHeaders(),
+                    url: `${ajaxBase}/capturas/${id}`,
                     success: data => {
                         const nombre = prompt('Nombre común', data.nombre_comun);
                         if (nombre === null) return;
                         const num = prompt('Número de individuos', data.numero_individuos);
                         const peso = prompt('Peso estimado', data.peso_estimado);
                         $.ajax({
-                            url: `${apiBase}/isospam/capturas/${id}`,
+                            url: `${ajaxBase}/capturas/${id}`,
                             method: 'PUT',
-                            headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders()),
+                            contentType: 'application/json',
                             data: JSON.stringify({
                                 nombre_comun: nombre,
                                 numero_individuos: num,
@@ -299,9 +292,8 @@
             function eliminarCaptura(id) {
                 if (!confirm('¿Eliminar captura?')) return;
                 $.ajax({
-                    url: `${apiBase}/isospam/capturas/${id}`,
+                    url: `${ajaxBase}/capturas/${id}`,
                     method: 'DELETE',
-                    headers: authHeaders(),
                     success: cargarCapturas
                 });
             }

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\RolMenuController;
 use App\Http\Controllers\RolPersonaController;
 use App\Http\Controllers\ViajeController;
 use App\Http\Controllers\CapturaController;
+use App\Http\Controllers\CapturaAjaxController;
 
 Route::get('/', function () {
     return view('home');
@@ -76,6 +77,11 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('viajes/{viaje}/seleccionar', [ViajeController::class, 'seleccionar'])->name('viajes.seleccionar');
     Route::resource('viajes', ViajeController::class)->except(['show']);
     Route::resource('capturas', CapturaController::class)->except(['show']);
+    Route::get('ajax/capturas-viaje', [CapturaAjaxController::class, 'index'])->name('ajax.capturas-viaje');
+    Route::get('ajax/capturas/{id}', [CapturaAjaxController::class, 'show'])->name('ajax.capturas.show');
+    Route::post('ajax/capturas', [CapturaAjaxController::class, 'store'])->name('ajax.capturas.store');
+    Route::put('ajax/capturas/{id}', [CapturaAjaxController::class, 'update'])->name('ajax.capturas.update');
+    Route::delete('ajax/capturas/{id}', [CapturaAjaxController::class, 'destroy'])->name('ajax.capturas.destroy');
 
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- Add CapturaAjaxController to proxy capture CRUD through Laravel
- Route capture AJAX endpoints through web routes
- Update viajes form to call local AJAX endpoints instead of external API

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689040b644e483338099ec9b05c2ab4e