### PR TITLE
Fetch species list for Captura form from API endpoint

### DIFF
--- a/app/Http/Controllers/CapturaController.php
+++ b/app/Http/Controllers/CapturaController.php
@@ -30,7 +30,6 @@ class CapturaController extends Controller
         $viajeId = $request->query('viaje_id');
         return view('capturas.form', [
             'viajeId' => $viajeId,
-            'especies' => $this->getEspecies(),
         ]);
     }
 
@@ -67,7 +66,6 @@ class CapturaController extends Controller
         $captura = $resp->json();
         return view('capturas.form', [
             'captura' => $captura,
-            'especies' => $this->getEspecies(),
             'viajeId' => $captura['viaje_id'] ?? null,
         ]);
     }
@@ -110,9 +108,4 @@ class CapturaController extends Controller
         return back()->withErrors(['error' => 'Error al eliminar']);
     }
 
-    private function getEspecies(): array
-    {
-        $resp = $this->apiService->get('/especies');
-        return $resp->successful() ? $resp->json() : [];
-    }
 }

--- a/resources/views/capturas/form.blade.php
+++ b/resources/views/capturas/form.blade.php
@@ -22,11 +22,8 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Especie</label>
-        <select name="especie_id" class="form-control">
+        <select name="especie_id" id="especie_id" class="form-control">
             <option value="">Seleccione...</option>
-            @foreach($especies as $e)
-                <option value="{{ $e['id'] }}" @selected(old('especie_id', $captura['especie_id'] ?? '') == $e['id'])>{{ $e['nombre'] ?? '' }}</option>
-            @endforeach
         </select>
     </div>
     <div class="form-check mb-3">
@@ -43,4 +40,28 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('viajes.edit', ['viaje' => old('viaje_id', $viajeId ?? $captura['viaje_id'] ?? ''), 'por_finalizar' => 1]) }}" class="btn btn-secondary">Cancelar</a>
 </form>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const select = document.getElementById('especie_id');
+    const selected = @json(old('especie_id', $captura['especie_id'] ?? ''));
+
+    fetch('http://186.46.31.211:9090/isospam/especies')
+        .then(response => response.json())
+        .then(data => {
+            data.forEach(e => {
+                const opt = document.createElement('option');
+                opt.value = e.id;
+                opt.textContent = e.nombre;
+                if (String(e.id) === String(selected)) {
+                    opt.selected = true;
+                }
+                select.appendChild(opt);
+            });
+        })
+        .catch(err => console.error('Error al cargar especies:', err));
+});
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- Load species list in Captura form via HTTP call to `/isospam/especies`
- Remove server-side species fetching from `CapturaController`

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68912f807fbc83338542e63b27847b4e