### PR TITLE
Validate campaign date ordering

### DIFF
--- a/app/Http/Controllers/CampaniaController.php
+++ b/app/Http/Controllers/CampaniaController.php
@@ -29,9 +29,12 @@ class CampaniaController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'fechainicio' => ['nullable', 'date'],
-            'fechafin' => ['nullable', 'date'],
+            'fechainicio' => ['nullable', 'date', 'before_or_equal:fechafin'],
+            'fechafin' => ['nullable', 'date', 'after_or_equal:fechainicio'],
             'descripcion' => ['nullable', 'string'],
+        ], [
+            'fechainicio.before_or_equal' => 'La fecha de inicio no puede ser mayor a la fecha fin.',
+            'fechafin.after_or_equal' => 'La fecha fin no puede ser menor a la fecha inicio.',
         ]);
 
         $response = $this->apiService->post('/campanias', $data);
@@ -58,9 +61,12 @@ class CampaniaController extends Controller
     public function update(Request $request, string $id)
     {
         $data = $request->validate([
-            'fechainicio' => ['nullable', 'date'],
-            'fechafin' => ['nullable', 'date'],
+            'fechainicio' => ['nullable', 'date', 'before_or_equal:fechafin'],
+            'fechafin' => ['nullable', 'date', 'after_or_equal:fechainicio'],
             'descripcion' => ['nullable', 'string'],
+        ], [
+            'fechainicio.before_or_equal' => 'La fecha de inicio no puede ser mayor a la fecha fin.',
+            'fechafin.after_or_equal' => 'La fecha fin no puede ser menor a la fecha inicio.',
         ]);
 
         $response = $this->apiService->put("/campanias/{$id}", $data);

--- a/resources/views/campanias/form.blade.php
+++ b/resources/views/campanias/form.blade.php
@@ -26,3 +26,47 @@
     <a href="{{ route('campanias.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
 @endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.querySelector('form');
+    const fechainicio = form.querySelector('input[name="fechainicio"]');
+    const fechafin = form.querySelector('input[name="fechafin"]');
+
+    function updateLimits() {
+        if (fechainicio.value) {
+            fechafin.min = fechainicio.value;
+        }
+        if (fechafin.value) {
+            fechainicio.max = fechafin.value;
+        }
+    }
+
+    fechainicio.addEventListener('change', function () {
+        updateLimits();
+        if (fechafin.value && fechainicio.value > fechafin.value) {
+            alert('La fecha de inicio no puede ser mayor a la fecha fin.');
+            fechainicio.value = '';
+        }
+    });
+
+    fechafin.addEventListener('change', function () {
+        updateLimits();
+        if (fechainicio.value && fechafin.value < fechainicio.value) {
+            alert('La fecha fin no puede ser menor a la fecha inicio.');
+            fechafin.value = '';
+        }
+    });
+
+    form.addEventListener('submit', function (e) {
+        if (fechainicio.value && fechafin.value && fechainicio.value > fechafin.value) {
+            e.preventDefault();
+            alert('La fecha de inicio no puede ser mayor a la fecha fin.');
+        }
+    });
+
+    updateLimits();
+});
+</script>
+@endsection


### PR DESCRIPTION
## Summary
- validate campaign start date is before end date on server
- add frontend check preventing invalid campaign date ranges

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957688f88483338ec7bca5ad826638