### PR TITLE
feat: add observadores viaje crud

### DIFF
--- a/app/Http/Controllers/ObservadorViajeAjaxController.php
+++ b/app/Http/Controllers/ObservadorViajeAjaxController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class ObservadorViajeAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $resp = $this->apiService->get('/observadores-viaje', [
+            'viaje_id' => $request->query('viaje_id'),
+        ]);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function show(string $id)
+    {
+        $resp = $this->apiService->get("/observadores-viaje/{$id}");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'tipo_observador_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+        ]);
+
+        $resp = $this->apiService->post('/observadores-viaje', $data);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'tipo_observador_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+        ]);
+
+        $resp = $this->apiService->put("/observadores-viaje/{$id}", $data);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function destroy(string $id)
+    {
+        $resp = $this->apiService->delete("/observadores-viaje/{$id}");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/app/Http/Controllers/ObservadorViajeController.php
+++ b/app/Http/Controllers/ObservadorViajeController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class ObservadorViajeController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $viajeId = $request->query('viaje_id');
+        $observadores = [];
+        if ($viajeId) {
+            $resp = $this->apiService->get('/observadores-viaje', ['viaje_id' => $viajeId]);
+            $observadores = $resp->successful() ? $resp->json() : [];
+        }
+        return view('observadores-viaje.index', [
+            'observadores' => $observadores,
+            'viajeId' => $viajeId,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        $viajeId = $request->query('viaje_id');
+        return view('observadores-viaje.form', [
+            'viajeId' => $viajeId,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'tipo_observador_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+        ]);
+
+        $resp = $this->apiService->post('/observadores-viaje', $data);
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $data['viaje_id'], 'por_finalizar' => 1])
+                ->with('success', 'Observador registrado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $resp = $this->apiService->get("/observadores-viaje/{$id}");
+        if (! $resp->successful()) {
+            abort(404);
+        }
+        $observador = $resp->json();
+        return view('observadores-viaje.form', [
+            'observador' => $observador,
+            'viajeId' => $observador['viaje_id'] ?? null,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'tipo_observador_id' => ['required', 'integer'],
+            'persona_idpersona' => ['required', 'integer'],
+        ]);
+
+        $resp = $this->apiService->put("/observadores-viaje/{$id}", $data);
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $data['viaje_id'], 'por_finalizar' => 1])
+                ->with('success', 'Observador actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(Request $request, string $id)
+    {
+        $viajeId = $request->query('viaje_id');
+        $resp = $this->apiService->delete("/observadores-viaje/{$id}");
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $viajeId, 'por_finalizar' => 1])
+                ->with('success', 'Observador eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}
+

--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -86,9 +86,13 @@ class ViajeController extends Controller
         $respCapturas = $this->apiService->get('/capturas-viaje', ['viaje_id' => $id]);
         $capturas = $respCapturas->successful() ? $respCapturas->json() : [];
 
+        $respObservadores = $this->apiService->get('/observadores-viaje', ['viaje_id' => $id]);
+        $observadores = $respObservadores->successful() ? $respObservadores->json() : [];
+
         return view('viajes.form', [
             'viaje' => $viaje,
             'capturas' => $capturas,
+            'observadores' => $observadores,
             'muelles' => $this->getMuelles(),
             'puertos' => $this->getPuertos(),
             'embarcaciones' => $this->getEmbarcaciones(),

--- a/resources/views/observadores-viaje/form.blade.php
+++ b/resources/views/observadores-viaje/form.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($observador) ? 'Editar' : 'Nuevo' }} Observador</h3>
+<form method="POST" action="{{ isset($observador) ? route('observadores-viaje.update', $observador['id']) : route('observadores-viaje.store') }}">
+    @csrf
+    @isset($observador)
+        @method('PUT')
+    @endisset
+    <input type="hidden" name="viaje_id" value="{{ old('viaje_id', $viajeId ?? $observador['viaje_id'] ?? '') }}">
+    <div class="mb-3">
+        <label class="form-label">Tipo de Observador</label>
+        <select name="tipo_observador_id" id="tipo_observador_id" class="form-control">
+            <option value="">Seleccione...</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Persona</label>
+        <select name="persona_idpersona" id="persona_idpersona" class="form-control">
+            <option value="">Seleccione...</option>
+        </select>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('viajes.edit', ['viaje' => old('viaje_id', $viajeId ?? $observador['viaje_id'] ?? ''), 'por_finalizar' => 1]) }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const tipoSelect = document.getElementById('tipo_observador_id');
+    const personaSelect = $('#persona_idpersona');
+    const selectedTipo = @json(old('tipo_observador_id', $observador['tipo_observador_id'] ?? ''));
+    fetch('http://186.46.31.211:9090/isospam/tipo-observador')
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(t => {
+                const opt = new Option(t.descripcion, t.id, false, String(t.id) === String(selectedTipo));
+                tipoSelect.appendChild(opt);
+            });
+        });
+    personaSelect.select2({
+        width: '100%',
+        placeholder: 'Seleccione...',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('ajax.personas') }}",
+            dataType: 'json',
+            delay: 250,
+            data: params => ({ filtro: params.term, rol: 'OBS' }),
+            processResults: data => ({
+                results: $.map(data, p => ({ id: p.idpersona, text: `${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim() }))
+            }),
+            cache: true
+        }
+    });
+    const selectedPersona = @json(old('persona_idpersona', $observador['persona_idpersona'] ?? ''));
+    if (selectedPersona) {
+        fetch(`http://186.46.31.211:9090/isospam/personas/${selectedPersona}`)
+            .then(r => r.json())
+            .then(p => {
+                const opt = new Option(`${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim(), p.idpersona, true, true);
+                personaSelect.append(opt).trigger('change');
+            });
+    }
+});
+</script>
+@endsection
+

--- a/resources/views/observadores-viaje/index.blade.php
+++ b/resources/views/observadores-viaje/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Observadores</h3>
+    @if($viajeId)
+        <a href="{{ route('observadores-viaje.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nuevo</a>
+    @endif
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Tipo</th>
+            <th>Persona</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($observadores as $o)
+        <tr>
+            <td>{{ $o['tipo_observador_descripcion'] ?? '' }}</td>
+            <td>{{ $o['persona_nombres'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('observadores-viaje.edit', $o['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('observadores-viaje.destroy', $o['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <input type="hidden" name="viaje_id" value="{{ $viajeId }}">
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,8 @@ use App\Http\Controllers\RolPersonaController;
 use App\Http\Controllers\ViajeController;
 use App\Http\Controllers\CapturaController;
 use App\Http\Controllers\CapturaAjaxController;
+use App\Http\Controllers\ObservadorViajeController;
+use App\Http\Controllers\ObservadorViajeAjaxController;
 
 Route::get('/', function () {
     return view('home');
@@ -82,6 +84,13 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('ajax/capturas', [CapturaAjaxController::class, 'store'])->name('ajax.capturas.store');
     Route::put('ajax/capturas/{id}', [CapturaAjaxController::class, 'update'])->name('ajax.capturas.update');
     Route::delete('ajax/capturas/{id}', [CapturaAjaxController::class, 'destroy'])->name('ajax.capturas.destroy');
+
+    Route::resource('observadores-viaje', ObservadorViajeController::class)->except(['show']);
+    Route::get('ajax/observadores-viaje', [ObservadorViajeAjaxController::class, 'index'])->name('ajax.observadores-viaje');
+    Route::get('ajax/observadores-viaje/{id}', [ObservadorViajeAjaxController::class, 'show'])->name('ajax.observadores-viaje.show');
+    Route::post('ajax/observadores-viaje', [ObservadorViajeAjaxController::class, 'store'])->name('ajax.observadores-viaje.store');
+    Route::put('ajax/observadores-viaje/{id}', [ObservadorViajeAjaxController::class, 'update'])->name('ajax.observadores-viaje.update');
+    Route::delete('ajax/observadores-viaje/{id}', [ObservadorViajeAjaxController::class, 'destroy'])->name('ajax.observadores-viaje.destroy');
 
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add controllers and routes to manage viaje observers
- integrate observer management into viaje form
- provide views and ajax handlers for ObservadorViaje CRUD

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689594bafbfc83338c4d5eb3cc7d2ab1