### PR TITLE
Fix select2 search in observador modal

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -471,8 +471,9 @@
 
             $('#persona_idpersona').select2({
                 width: '100%',
-            placeholder: 'Seleccione...',
-            allowClear: true,
+                dropdownParent: $('#observador-modal'),
+                placeholder: 'Seleccione...',
+                allowClear: true,
                 ajax: {
                     url: "{{ route('ajax.personas') }}",
                     dataType: 'json',


### PR DESCRIPTION
## Summary
- ensure persona select2 dropdown is bound to the modal so typing works

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68959a8095ec8333ab419c980dc9293c