### PR TITLE
Fix custom helper redeclarations

### DIFF
--- a/config/db.php
+++ b/config/db.php
@@ -1,4 +1,3 @@
-
 <?php
 // config/db.php
 // Ajusta según tus credenciales reales
@@ -9,21 +8,27 @@ $DB_USER = getenv('DB_USER') ?: 'postgres';
 $DB_PASS = getenv('DB_PASS') ?: 'R34lM4dr1d*+*';
 $DB_SEARCH_PATH = getenv('DB_SEARCH_PATH') ?: 'pesca,public'; // ej. 'pesca'
 
-function db() {
-    static $pdo = null;
-    global $DB_HOST, $DB_PORT, $DB_NAME, $DB_USER, $DB_PASS, $DB_SEARCH_PATH;
-    if ($pdo === null) {
-        $dsn = "pgsql:host={$DB_HOST};port={$DB_PORT};dbname={$DB_NAME};";
-        $options = [
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-            PDO::ATTR_EMULATE_PREPARES => false,
-        ];
-        $pdo = new PDO($dsn, $DB_USER, $DB_PASS, $options);
-        if ($DB_SEARCH_PATH) {
-            $pdo->exec("SET search_path TO " . preg_replace('/[^a-zA-Z0-9_,]/', '', $DB_SEARCH_PATH) . ";");
+if (!function_exists('db')) {
+    function db() {
+        global $DB_HOST, $DB_PORT, $DB_NAME, $DB_USER, $DB_PASS, $DB_SEARCH_PATH;
+        static $pdo = null;
+        if ($pdo === null) {
+            $dsn = "pgsql:host={$DB_HOST};port={$DB_PORT};dbname={$DB_NAME};";
+            $options = [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ];
+            $pdo = new PDO($dsn, $DB_USER, $DB_PASS, $options);
+            if ($DB_SEARCH_PATH) {
+                $pdo->exec(
+                    "SET search_path TO " . preg_replace('/[^a-zA-Z0-9_,]/', '', $DB_SEARCH_PATH) . ";"
+                );
+            }
         }
+
+        return $pdo;
     }
-    return $pdo;
 }
-?>
+
+return [];

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,12 +114,14 @@ Route::middleware('ensure.logged.in')->group(function () {
 });
 
 
-function runReporte(string $file) {
-    $path = public_path("reportes/{$file}");
-    abort_unless(is_file($path), 404, 'Reporte no encontrado');
-    ob_start();
-    include $path;     // ejecuta rXX.php
-    return response(ob_get_clean());
+if (!function_exists('runReporte')) {
+    function runReporte(string $file) {
+        $path = public_path("reportes/{$file}");
+        abort_unless(is_file($path), 404, 'Reporte no encontrado');
+        ob_start();
+        include $path;     // ejecuta rXX.php
+        return response(ob_get_clean());
+    }
 }
 
 // Operativos


### PR DESCRIPTION
## Summary
- Avoid conflicts with Laravel's helper `db()` by defining the dashboard helper only when absent
- Prevent duplicate definitions of `runReporte` when routes are loaded multiple times

## Testing
- `php artisan config:clear`
- `php artisan config:cache`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689bf4395ef883338c680eba5802901e