### PR TITLE
Corrige comillas en consultas raw de reportes

### DIFF
--- a/app/Http/Controllers/EconomiaController.php
+++ b/app/Http/Controllers/EconomiaController.php
@@ -57,7 +57,7 @@ class EconomiaController extends Controller {
       ->leftJoin('public.puerto as p','p.id','=','v.puerto_arribo_id')
       ->when($arte, fn($qq)=>$qq->whereRaw('lower(ta.nombre)=lower(?)',[$arte]))
       ->when($puerto, fn($qq)=>$qq->whereRaw('lower(p.nombre)=lower(?)',[$puerto]))
-      ->selectRaw('coalesce(ta.nombre,coalesce(p.nombre,'Total')) as grupo, sum(ev.precio) as ingresos')
+      ->selectRaw("coalesce(ta.nombre,coalesce(p.nombre,'Total')) as grupo, sum(ev.precio) as ingresos")
       ->groupBy('grupo');
 
     $cos = DB::connection('reportes')->table('public.economia_insumo as ei')
@@ -67,7 +67,7 @@ class EconomiaController extends Controller {
       ->leftJoin('public.puerto as p','p.id','=','v.puerto_arribo_id')
       ->when($arte, fn($qq)=>$qq->whereRaw('lower(ta.nombre)=lower(?)',[$arte]))
       ->when($puerto, fn($qq)=>$qq->whereRaw('lower(p.nombre)=lower(?)',[$puerto]))
-      ->selectRaw('coalesce(ta.nombre,coalesce(p.nombre,'Total')) as grupo, sum(ei.cantidad) as costos')
+      ->selectRaw("coalesce(ta.nombre,coalesce(p.nombre,'Total')) as grupo, sum(ei.cantidad) as costos")
       ->groupBy('grupo');
 
     $ing = collect($ing->get())->keyBy('grupo');
@@ -114,9 +114,9 @@ class EconomiaController extends Controller {
       ->when($tipo, fn($qq)=>$qq->whereRaw('lower(ti.nombre)=lower(?)',[$tipo]))
       ->when($periodo, fn($qq)=>$qq->whereRaw("to_char(v.fecha_arribo,'YYYY-MM') = ?",[$periodo]))
       ->when($arte, fn($qq)=>$qq->whereRaw('lower(ta.nombre)=lower(?)',[$arte]))
-      ->selectRaw('coalesce(ti.nombre,'Total') as tipo, sum(ei.cantidad) as costo_total,
+      ->selectRaw("coalesce(ti.nombre,'Total') as tipo, sum(ei.cantidad) as costo_total,
                   avg(EXTRACT(EPOCH FROM (v.hora_arribo - v.hora_zarpe))/3600.0) as horas,
-                  sum(ei.cantidad)/nullif(sum(EXTRACT(EPOCH FROM (v.hora_arribo - v.hora_zarpe))/3600.0),0) as costo_por_hora')
+                  sum(ei.cantidad)/nullif(sum(EXTRACT(EPOCH FROM (v.hora_arribo - v.hora_zarpe))/3600.0),0) as costo_por_hora")
       ->groupBy('tipo')
       ->orderByDesc('costo_total');
     $rows = $q->get();

--- a/app/Http/Controllers/KpiController.php
+++ b/app/Http/Controllers/KpiController.php
@@ -21,7 +21,7 @@ class KpiController extends Controller {
     $q = DB::connection('reportes')->table('public.economia_ventas as ev')
       ->join('public.captura as c','c.id','=','ev.captura_id')
       ->leftJoin('public.especie as e','e.id','=','c.especie_id')
-      ->selectRaw('coalesce(e.nombre,'(sin especie)') as especie, sum(ev.precio) as ingreso_total, avg(ev.precio) as ingreso_prom')
+      ->selectRaw("coalesce(e.nombre,'(sin especie)') as especie, sum(ev.precio) as ingreso_total, avg(ev.precio) as ingreso_prom")
       ->groupBy('especie')
       ->orderByDesc('ingreso_total')
       ->limit(10);


### PR DESCRIPTION
## Resumen
- Corrige comillas en consulta de KPI de valor para evitar error de sintaxis
- Ajusta consultas de margen y costos de insumos con comillas apropiadas

## Pruebas
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689bff753b448333af09bfd21b30ecdc