### PR TITLE
Add EconomiaInsumo CRUD for viajes

### DIFF
--- a/app/Http/Controllers/EconomiaInsumoAjaxController.php
+++ b/app/Http/Controllers/EconomiaInsumoAjaxController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class EconomiaInsumoAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $viajeId = $request->query('viaje_id');
+        $resp = $this->apiService->get("/economia-insumo-viaje/{$viajeId}");
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function show(string $id)
+    {
+        $resp = $this->apiService->get("/economia-insumo/{$id}");
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'unidad_insumo_id' => ['required', 'integer'],
+            'tipo_insumo_id' => ['required', 'integer'],
+            'cantidad' => ['required', 'numeric'],
+        ]);
+        $resp = $this->apiService->post('/economia-insumo', $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'unidad_insumo_id' => ['required', 'integer'],
+            'tipo_insumo_id' => ['required', 'integer'],
+            'cantidad' => ['required', 'numeric'],
+        ]);
+        $resp = $this->apiService->put("/economia-insumo/{$id}", $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function destroy(string $id)
+    {
+        $resp = $this->apiService->delete("/economia-insumo/{$id}");
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/app/Http/Controllers/EconomiaInsumoController.php
+++ b/app/Http/Controllers/EconomiaInsumoController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class EconomiaInsumoController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $viajeId = $request->query('viaje_id');
+        $economias = [];
+        if ($viajeId) {
+            $resp = $this->apiService->get("/economia-insumo-viaje/{$viajeId}");
+            $economias = $resp->successful() ? $resp->json() : [];
+        }
+        return view('economia-insumo.index', [
+            'economiaInsumos' => $economias,
+            'viajeId' => $viajeId,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        $viajeId = $request->query('viaje_id');
+        return view('economia-insumo.form', [
+            'viajeId' => $viajeId,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'unidad_insumo_id' => ['required', 'integer'],
+            'tipo_insumo_id' => ['required', 'integer'],
+            'cantidad' => ['required', 'numeric'],
+        ]);
+
+        $resp = $this->apiService->post('/economia-insumo', $data);
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $data['viaje_id'], 'por_finalizar' => 1])
+                ->with('success', 'Economía de insumo registrada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function edit(string $id)
+    {
+        $resp = $this->apiService->get("/economia-insumo/{$id}");
+        if (! $resp->successful()) {
+            abort(404);
+        }
+        $economia = $resp->json();
+        return view('economia-insumo.form', [
+            'economia' => $economia,
+            'viajeId' => $economia['viaje_id'] ?? null,
+        ]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'viaje_id' => ['required', 'integer'],
+            'unidad_insumo_id' => ['required', 'integer'],
+            'tipo_insumo_id' => ['required', 'integer'],
+            'cantidad' => ['required', 'numeric'],
+        ]);
+
+        $resp = $this->apiService->put("/economia-insumo/{$id}", $data);
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $data['viaje_id'], 'por_finalizar' => 1])
+                ->with('success', 'Economía de insumo actualizada correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy(Request $request, string $id)
+    {
+        $viajeId = $request->query('viaje_id');
+        $resp = $this->apiService->delete("/economia-insumo/{$id}");
+
+        if ($resp->successful()) {
+            return redirect()
+                ->route('viajes.edit', ['viaje' => $viajeId, 'por_finalizar' => 1])
+                ->with('success', 'Economía de insumo eliminada');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+}
+

--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -95,12 +95,16 @@ class ViajeController extends Controller
         $respParametros = $this->apiService->get('/parametros-ambientales', ['viaje_id' => $id]);
         $parametrosAmbientales = $respParametros->successful() ? $respParametros->json() : [];
 
+        $respEconomia = $this->apiService->get("/economia-insumo-viaje/{$id}");
+        $economiaInsumos = $respEconomia->successful() ? $respEconomia->json() : [];
+
         return view('viajes.form', [
             'viaje' => $viaje,
             'tripulantes' => $tripulantes,
             'capturas' => $capturas,
             'observadores' => $observadores,
             'parametrosAmbientales' => $parametrosAmbientales,
+            'economiaInsumos' => $economiaInsumos,
             'muelles' => $this->getMuelles(),
             'puertos' => $this->getPuertos(),
             'embarcaciones' => $this->getEmbarcaciones(),

--- a/resources/views/economia-insumo/form.blade.php
+++ b/resources/views/economia-insumo/form.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<h3>{{ isset($economia) ? 'Editar' : 'Nuevo' }} Economía de Insumo</h3>
+<form method="POST" action="{{ isset($economia) ? route('economia-insumo.update', $economia['id']) : route('economia-insumo.store') }}">
+    @csrf
+    @isset($economia)
+        @method('PUT')
+    @endisset
+    <input type="hidden" name="viaje_id" value="{{ old('viaje_id', $viajeId ?? $economia['viaje_id'] ?? '') }}">
+    <div class="mb-3">
+        <label class="form-label">Tipo de Insumo</label>
+        <select name="tipo_insumo_id" id="tipo_insumo_id" class="form-control">
+            <option value="">Seleccione...</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Unidad de Insumo</label>
+        <select name="unidad_insumo_id" id="unidad_insumo_id" class="form-control">
+            <option value="">Seleccione...</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Cantidad</label>
+        <input type="number" step="any" name="cantidad" class="form-control" value="{{ old('cantidad', $economia['cantidad'] ?? '') }}">
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('viajes.edit', ['viaje' => old('viaje_id', $viajeId ?? $economia['viaje_id'] ?? ''), 'por_finalizar' => 1]) }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const tipoSelect = document.getElementById('tipo_insumo_id');
+    const unidadSelect = document.getElementById('unidad_insumo_id');
+    const selectedTipo = @json(old('tipo_insumo_id', $economia['tipo_insumo_id'] ?? ''));
+    const selectedUnidad = @json(old('unidad_insumo_id', $economia['unidad_insumo_id'] ?? ''));
+
+    fetch('http://186.46.31.211:9090/isospam/tipos-insumo')
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(t => {
+                const opt = new Option(t.nombre, t.id, false, String(t.id) === String(selectedTipo));
+                tipoSelect.appendChild(opt);
+            });
+        });
+
+    fetch('http://186.46.31.211:9090/isospam/unidades-insumo')
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(u => {
+                const opt = new Option(u.nombre, u.id, false, String(u.id) === String(selectedUnidad));
+                unidadSelect.appendChild(opt);
+            });
+        });
+});
+</script>
+@endsection
+

--- a/resources/views/economia-insumo/index.blade.php
+++ b/resources/views/economia-insumo/index.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Economía de Insumos</h3>
+    @if($viajeId)
+        <a href="{{ route('economia-insumo.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nuevo</a>
+    @endif
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Tipo</th>
+            <th>Unidad</th>
+            <th>Cantidad</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($economiaInsumos as $e)
+        <tr>
+            <td>{{ $e['nombre_tipo'] ?? '' }}</td>
+            <td>{{ $e['nombre_unidad'] ?? '' }}</td>
+            <td>{{ $e['cantidad'] ?? '' }}</td>
+            <td class="text-right">
+                <a href="{{ route('economia-insumo.edit', $e['id']) }}" class="btn btn-sm btn-secondary">Editar</a>
+                <form action="{{ route('economia-insumo.destroy', $e['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <input type="hidden" name="viaje_id" value="{{ $viajeId }}">
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,11 +44,13 @@ use App\Http\Controllers\CapturasController;
 use App\Http\Controllers\BiologiaController;
 use App\Http\Controllers\ZonasController;
 use App\Http\Controllers\EconomiaController;
+use App\Http\Controllers\EconomiaInsumoController;
 use App\Http\Controllers\FlotaController;
 use App\Http\Controllers\KpiController;
 use App\Http\Controllers\AlertasController;
 use App\Http\Controllers\ApiController;
 use App\Http\Controllers\ParametroAmbientalAjaxController;
+use App\Http\Controllers\EconomiaInsumoAjaxController;
 
 Route::get('/', function () {
     return view('home');
@@ -117,6 +119,13 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('ajax/parametros-ambientales', [ParametroAmbientalAjaxController::class, 'store'])->name('ajax.parametros-ambientales.store');
     Route::put('ajax/parametros-ambientales/{id}', [ParametroAmbientalAjaxController::class, 'update'])->name('ajax.parametros-ambientales.update');
     Route::delete('ajax/parametros-ambientales/{id}', [ParametroAmbientalAjaxController::class, 'destroy'])->name('ajax.parametros-ambientales.destroy');
+
+    Route::resource('economia-insumo', EconomiaInsumoController::class)->except(['show']);
+    Route::get('ajax/economia-insumo', [EconomiaInsumoAjaxController::class, 'index'])->name('ajax.economia-insumo');
+    Route::get('ajax/economia-insumo/{id}', [EconomiaInsumoAjaxController::class, 'show'])->name('ajax.economia-insumo.show');
+    Route::post('ajax/economia-insumo', [EconomiaInsumoAjaxController::class, 'store'])->name('ajax.economia-insumo.store');
+    Route::put('ajax/economia-insumo/{id}', [EconomiaInsumoAjaxController::class, 'update'])->name('ajax.economia-insumo.update');
+    Route::delete('ajax/economia-insumo/{id}', [EconomiaInsumoAjaxController::class, 'destroy'])->name('ajax.economia-insumo.destroy');
 
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- integrate economia insumo CRUD for trips
- add controllers, routes, views and JS
- load economia insumo data in viaje edit view

## Testing
- `composer test` *(fails: Failed opening required '/workspace/ISOSPAM/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689c1e2e19748333881d2bc1f9edcd3a