### PR TITLE
feat: add dynamic campaign fields for viajes

### DIFF
--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -25,4 +25,19 @@
         <a href="{{ route('viajes.pendientes') }}" class="btn btn-secondary">Volver</a>
     </div>
 </div>
+@if(!empty($viaje['respuestas_multifinalitaria']))
+    <div class="card mt-3">
+        <div class="card-header">
+            <h3 class="card-title">Campos dinámicos</h3>
+        </div>
+        <div class="card-body">
+            <dl class="row">
+                @foreach($viaje['respuestas_multifinalitaria'] as $r)
+                    <dt class="col-sm-4">{{ $r['nombre_pregunta'] ?? '' }}</dt>
+                    <dd class="col-sm-8">{{ $r['respuesta'] ?? '' }}</dd>
+                @endforeach
+            </dl>
+        </div>
+    </div>
+@endif
 @endsection


### PR DESCRIPTION
## Summary
- load dynamic fields by campaign in viaje forms
- submit dynamic field responses when saving
- show dynamic field answers in viaje detail view

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689c47782dd4833381e6881fe4878f58