### PR TITLE
Include dynamic answers on viaje details

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -255,8 +255,23 @@ class ViajeController extends Controller
             abort(404);
         }
 
+        $viaje = $response->json();
+
+        if (! empty($viaje['campania_id'] ?? null)) {
+            $respMulti = $this->apiService->get('/respuestas-multifinalitaria', [
+                'campania_id' => $viaje['campania_id'],
+                'tabla_relacionada' => 'viaje',
+                'relacion_id' => $viaje['id'] ?? $id,
+            ]);
+            $viaje['respuestas_multifinalitaria'] = $respMulti->successful()
+                ? $respMulti->json()
+                : [];
+        } else {
+            $viaje['respuestas_multifinalitaria'] = [];
+        }
+
         return view('viajes.mostrar', [
-            'viaje' => $response->json(),
+            'viaje' => $viaje,
         ]);
     }
 

--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.dashboard')
 
 @section('content')
-<div class="card">
+<div class="card mb-3">
     <div class="card-header">
         <h3 class="card-title">Detalle del viaje</h3>
     </div>
@@ -21,12 +21,9 @@
             <dd class="col-sm-8">{{ $viaje['observaciones'] ?? '' }}</dd>
         </dl>
     </div>
-    <div class="card-footer">
-        <a href="{{ route('viajes.pendientes') }}" class="btn btn-secondary">Volver</a>
-    </div>
 </div>
 @if(!empty($viaje['respuestas_multifinalitaria']))
-    <div class="card mt-3">
+    <div class="card mb-3">
         <div class="card-header">
             <h3 class="card-title">Campos dinámicos</h3>
         </div>
@@ -40,4 +37,6 @@
         </div>
     </div>
 @endif
+
+<a href="{{ route('viajes.pendientes') }}" class="btn btn-secondary">Volver</a>
 @endsection


### PR DESCRIPTION
## Summary
- Fetch `respuestas_multifinalitaria` when showing a viaje
- Display dynamic field answers in a dedicated "Campos dinámicos" card

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689c497ed7248333b5bdc91d7c0c388a