### PR TITLE
Handle array options in dynamic fields

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -152,7 +152,11 @@
                                     <select name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control">
                                         <option value="">Seleccione...</option>
                                         @foreach($opciones as $opt)
-                                            <option value="{{ $opt }}" @selected(($resp['respuesta'] ?? '') == $opt)>{{ $opt }}</option>
+                                            @php
+                                                $value = is_array($opt) ? ($opt['valor'] ?? '') : (string) $opt;
+                                                $text = is_array($opt) ? ($opt['texto'] ?? '') : (string) $opt;
+                                            @endphp
+                                            <option value="{{ $value }}" @selected(($resp['respuesta'] ?? '') == $value)>{{ $text }}</option>
                                         @endforeach
                                     </select>
                                     @break


### PR DESCRIPTION
## Summary
- load dynamic fields from campaign `campos` when creating viajes
- reuse viaje `respuestas_multifinalitaria` when editing and normalize option arrays

## Testing
- `php artisan test`
- `curl -s -o /tmp/route.html -w "%{http_code}\n" http://127.0.0.1:8000/viajes/1/edit?por_finalizar=1` *(fails: Database file at path [C:/xampp/htdocs/ISOSPAM-1/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c4ccea9288333b745be53d94b8686