### PR TITLE
Handle array options in dynamic fields

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -104,9 +104,19 @@ class ViajeController extends Controller
         $respEconomia = $this->apiService->get("/economia-insumo-viaje/{$id}");
         $economiaInsumos = $respEconomia->successful() ? $respEconomia->json() : [];
 
-        $camposDinamicos = ! empty($viaje['campania_id'])
-            ? $this->getCamposDinamicos((int) $viaje['campania_id'])
-            : [];
+        $respRespuestas = $this->apiService->get("/respuestas-multifinalitaria/viaje/{$id}");
+        $respuestasMulti = $respRespuestas->successful() ? $respRespuestas->json() : [];
+        $viaje['respuestas_multifinalitaria'] = $respuestasMulti;
+
+        $camposDinamicos = collect($respuestasMulti)
+            ->map(fn($r) => [
+                'id' => $r['tabla_multifinalitaria_id'] ?? null,
+                'nombre_pregunta' => $r['nombre_pregunta'] ?? '',
+                'tipo_pregunta' => $r['tipo_pregunta'] ?? 'INPUT',
+                'opciones' => is_array($r['opciones'] ?? null)
+                    ? json_encode($r['opciones'])
+                    : ($r['opciones'] ?? '[]'),
+            ])->all();
 
         return view('viajes.form', [
             'viaje' => $viaje,
@@ -324,11 +334,23 @@ class ViajeController extends Controller
 
     private function getCamposDinamicos(int $campaniaId): array
     {
-        $response = $this->apiService->get('/tabla-multifinalitaria', [
-            'campania_id' => $campaniaId,
-            'tabla_relacionada' => 'viaje',
-        ]);
+        $response = $this->apiService->get("/campanias/{$campaniaId}");
+        if (! $response->successful()) {
+            return [];
+        }
 
-        return $response->successful() ? $response->json() : [];
+        $campania = $response->json();
+        $campos = $campania['campos'] ?? [];
+
+        return collect($campos)
+            ->filter(fn($c) => ($c['tabla_relacionada'] ?? '') === 'viaje')
+            ->map(function ($c) {
+                $c['opciones'] = is_array($c['opciones'] ?? null)
+                    ? json_encode($c['opciones'])
+                    : ($c['opciones'] ?? '[]');
+                return $c;
+            })
+            ->values()
+            ->all();
     }
 }

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -152,7 +152,11 @@
                                     <select name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control">
                                         <option value="">Seleccione...</option>
                                         @foreach($opciones as $opt)
-                                            <option value="{{ $opt }}" @selected(($resp['respuesta'] ?? '') == $opt)>{{ $opt }}</option>
+                                            @php
+                                                $value = is_array($opt) ? ($opt['valor'] ?? '') : (string) $opt;
+                                                $text = is_array($opt) ? ($opt['texto'] ?? '') : (string) $opt;
+                                            @endphp
+                                            <option value="{{ $value }}" @selected(($resp['respuesta'] ?? '') == $value)>{{ $text }}</option>
                                         @endforeach
                                     </select>
                                     @break


### PR DESCRIPTION
## Summary
- load dynamic fields from campaign `campos` when creating viajes
- fetch viaje multifinalitaria responses from `/respuestas-multifinalitaria/viaje/{id}` when editing and normalize option arrays

## Testing
- `php artisan test`
- `curl -s -o /tmp/route.html -w "%{http_code}\n" http://127.0.0.1:8000/viajes/1/edit?por_finalizar=1` *(HTTP 500)*

------
https://chatgpt.com/codex/tasks/task_e_689c4ccea9288333b745be53d94b8686