### PR TITLE
Handle array options in dynamic fields

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -47,7 +47,9 @@ class ViajeController extends Controller
 
     public function store(Request $request)
     {
-        $data = $request->validate([
+        $campos = $this->getCamposDinamicos((int) $request->input('campania_id'));
+
+        $rules = [
             'fecha_zarpe' => ['required', 'date'],
             'hora_zarpe' => ['required'],
             'fecha_arribo' => ['nullable', 'date', 'after_or_equal:fecha_zarpe'],
@@ -60,9 +62,18 @@ class ViajeController extends Controller
             'embarcacion_id' => ['required', 'integer'],
             'digitador_id' => ['required', 'integer'],
             'campania_id' => ['required', 'integer'],
-        ]);
+        ];
 
-        $data['respuestas_multifinalitaria'] = $request->input('respuestas_multifinalitaria', []);
+        foreach ($campos as $i => $campo) {
+            $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
+                ? ['required']
+                : ['nullable'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['required', 'integer'];
+        }
+
+        $data = $request->validate($rules);
+
+        $data['respuestas_multifinalitaria'] = $data['respuestas_multifinalitaria'] ?? [];
 
         if (($data['fecha_arribo'] ?? null) && ($data['hora_arribo'] ?? null)
             && $data['fecha_arribo'] === $data['fecha_zarpe']
@@ -104,9 +115,18 @@ class ViajeController extends Controller
         $respEconomia = $this->apiService->get("/economia-insumo-viaje/{$id}");
         $economiaInsumos = $respEconomia->successful() ? $respEconomia->json() : [];
 
-        $camposDinamicos = ! empty($viaje['campania_id'])
-            ? $this->getCamposDinamicos((int) $viaje['campania_id'])
-            : [];
+        $respuestasMulti = $viaje['respuestas_multifinalitaria'] ?? [];
+
+        $camposDinamicos = collect($respuestasMulti)
+            ->map(fn($r) => [
+                'id' => $r['tabla_multifinalitaria_id'] ?? null,
+                'nombre_pregunta' => $r['nombre_pregunta'] ?? '',
+                'tipo_pregunta' => $r['tipo_pregunta'] ?? 'INPUT',
+                'opciones' => is_array($r['opciones'] ?? null)
+                    ? json_encode($r['opciones'])
+                    : ($r['opciones'] ?? '[]'),
+                'requerido' => $r['requerido'] ?? false,
+            ])->all();
 
         return view('viajes.form', [
             'viaje' => $viaje,
@@ -127,7 +147,9 @@ class ViajeController extends Controller
 
     public function update(Request $request, string $id)
     {
-        $data = $request->validate([
+        $campos = $this->getCamposDinamicos((int) $request->input('campania_id'));
+
+        $rules = [
             'fecha_zarpe' => ['required', 'date'],
             'hora_zarpe' => ['required'],
             'fecha_arribo' => ['nullable', 'date', 'after_or_equal:fecha_zarpe'],
@@ -140,9 +162,18 @@ class ViajeController extends Controller
             'embarcacion_id' => ['required', 'integer'],
             'digitador_id' => ['required', 'integer'],
             'campania_id' => ['required', 'integer'],
-        ]);
+        ];
 
-        $data['respuestas_multifinalitaria'] = $request->input('respuestas_multifinalitaria', []);
+        foreach ($campos as $i => $campo) {
+            $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
+                ? ['required']
+                : ['nullable'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['required', 'integer'];
+        }
+
+        $data = $request->validate($rules);
+
+        $data['respuestas_multifinalitaria'] = $data['respuestas_multifinalitaria'] ?? [];
 
         if (($data['fecha_arribo'] ?? null) && ($data['hora_arribo'] ?? null)
             && $data['fecha_arribo'] === $data['fecha_zarpe']
@@ -324,11 +355,23 @@ class ViajeController extends Controller
 
     private function getCamposDinamicos(int $campaniaId): array
     {
-        $response = $this->apiService->get('/tabla-multifinalitaria', [
-            'campania_id' => $campaniaId,
-            'tabla_relacionada' => 'viaje',
-        ]);
+        $response = $this->apiService->get("/campanias/{$campaniaId}");
+        if (! $response->successful()) {
+            return [];
+        }
 
-        return $response->successful() ? $response->json() : [];
+        $campania = $response->json();
+        $campos = $campania['campos'] ?? [];
+
+        return collect($campos)
+            ->filter(fn($c) => ($c['tabla_relacionada'] ?? '') === 'viaje')
+            ->map(function ($c) {
+                $c['opciones'] = is_array($c['opciones'] ?? null)
+                    ? json_encode($c['opciones'])
+                    : ($c['opciones'] ?? '[]');
+                return $c;
+            })
+            ->values()
+            ->all();
     }
 }

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -143,31 +143,38 @@
                 @endphp
                 <div class="row">
                     @forelse($camposDinamicos ?? [] as $campo)
-                        @php $resp = $respuestas->get($campo['id'], []); @endphp
+                        @php
+                            $resp = $respuestas->get($campo['id'], []);
+                            $required = !empty($campo['requerido']) ? 'required' : '';
+                        @endphp
                         <div class="col-md-4 mb-3">
                             <label class="form-label">{{ $campo['nombre_pregunta'] ?? '' }}</label>
                             @switch($campo['tipo_pregunta'])
                                 @case('COMBO')
                                     @php $opciones = json_decode($campo['opciones'] ?? '[]', true) ?: []; @endphp
-                                    <select name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control">
+                                    <select name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" {{ $required }}>
                                         <option value="">Seleccione...</option>
                                         @foreach($opciones as $opt)
-                                            <option value="{{ $opt }}" @selected(($resp['respuesta'] ?? '') == $opt)>{{ $opt }}</option>
+                                            @php
+                                                $value = is_array($opt) ? ($opt['valor'] ?? '') : (string) $opt;
+                                                $text = is_array($opt) ? ($opt['texto'] ?? '') : (string) $opt;
+                                            @endphp
+                                            <option value="{{ $value }}" @selected(($resp['respuesta'] ?? '') == $value)>{{ $text }}</option>
                                         @endforeach
                                     </select>
                                     @break
                                 @case('INTEGER')
-                                    <input type="number" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}">
+                                    <input type="number" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}" {{ $required }}>
                                     @break
                                 @case('DATE')
-                                    <input type="date" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}">
+                                    <input type="date" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}" {{ $required }}>
                                     @break
                                 @case('TIME')
-                                    <input type="time" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}">
+                                    <input type="time" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}" {{ $required }}>
                                     @break
                                 @case('INPUT')
                                 @default
-                                    <input type="text" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}">
+                                    <input type="text" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}" {{ $required }}>
                             @endswitch
                             <input type="hidden" name="respuestas_multifinalitaria[{{ $loop->index }}][tabla_multifinalitaria_id]" value="{{ $campo['id'] }}">
                             @if(isset($resp['id']))
@@ -817,25 +824,30 @@
                 }
                 campos.forEach(function (campo, index) {
                     var control = '';
+                    var requerido = campo.requerido ? 'required' : '';
                     switch (campo.tipo_pregunta) {
                         case 'COMBO':
                             var opciones = [];
                             try { opciones = JSON.parse(campo.opciones || '[]'); } catch (e) {}
-                            control = '<select class="form-control" name="respuestas_multifinalitaria[' + index + '][respuesta]"><option value="">Seleccione...</option>';
-                            opciones.forEach(function(opt){ control += '<option value="' + opt + '">' + opt + '</option>'; });
+                            control = '<select class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]"><option value="">Seleccione...</option>';
+                              opciones.forEach(function(opt){
+                                var value = (typeof opt === 'object') ? (opt.valor || '') : String(opt);
+                                var text = (typeof opt === 'object') ? (opt.texto || '') : String(opt);
+                                control += '<option value="' + value + '">' + text + '</option>';
+                            });
                             control += '</select>';
                             break;
                         case 'INTEGER':
-                            control = '<input type="number" class="form-control" name="respuestas_multifinalitaria[' + index + '][respuesta]">';
+                            control = '<input type="number" class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]">';
                             break;
-                    case 'DATE':
-                            control = '<input type="date" class="form-control" name="respuestas_multifinalitaria[' + index + '][respuesta]">';
+                        case 'DATE':
+                            control = '<input type="date" class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]">';
                             break;
                         case 'TIME':
-                            control = '<input type="time" class="form-control" name="respuestas_multifinalitaria[' + index + '][respuesta]">';
+                            control = '<input type="time" class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]">';
                             break;
                         default:
-                            control = '<input type="text" class="form-control" name="respuestas_multifinalitaria[' + index + '][respuesta]">';
+                            control = '<input type="text" class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]">';
                     }
                     control += '<input type="hidden" name="respuestas_multifinalitaria[' + index + '][tabla_multifinalitaria_id]" value="' + campo.id + '">';
                     var col = $('<div class="col-md-4 mb-3"></div>');


### PR DESCRIPTION
## Summary
- load dynamic fields from campaign `campos` when creating viajes
- pull viaje's `respuestas_multifinalitaria` for existing dynamic fields instead of a separate endpoint
- validate required dynamic fields and mark required inputs

## Testing
- `php artisan test`
- `curl -s -o /tmp/route.html -w "%{http_code}\n" http://127.0.0.1:8000/viajes/1/edit?por_finalizar=1` *(HTTP 500)*

------
https://chatgpt.com/codex/tasks/task_e_689c4ccea9288333b745be53d94b8686