### PR TITLE
Add dynamic campaign fields endpoint and AJAX usage

### DIFF
--- a/app/Http/Controllers/CampaniaController.php
+++ b/app/Http/Controllers/CampaniaController.php
@@ -88,4 +88,35 @@ class CampaniaController extends Controller
 
         return back()->withErrors(['error' => 'Error al eliminar']);
     }
+
+    public function camposDinamicos(Request $request)
+    {
+        $campaniaId = $request->input('campania_id');
+        $tabla = $request->input('tabla_relacionada');
+
+        if (!$campaniaId || !$tabla) {
+            return response()->json([]);
+        }
+
+        $response = $this->apiService->get("/campanias/{$campaniaId}");
+        if (!$response->successful()) {
+            return response()->json([]);
+        }
+
+        $campania = $response->json();
+        $campos = $campania['campos'] ?? [];
+
+        $filtrados = collect($campos)
+            ->filter(fn($c) => ($c['tabla_relacionada'] ?? '') === $tabla)
+            ->map(function ($c) {
+                $c['opciones'] = is_array($c['opciones'] ?? null)
+                    ? json_encode($c['opciones'])
+                    : ($c['opciones'] ?? '[]');
+                return $c;
+            })
+            ->values()
+            ->all();
+
+        return response()->json($filtrados);
+    }
 }

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -869,7 +869,7 @@
                     renderCamposDinamicos([]);
                     return;
                 }
-                $.get('/ajax/campos-dinamicos', { campania_id: campaniaId, tabla_relacionada: 'viaje' }, function (data) {
+                $.get('{{ url('ajax/campos-dinamicos') }}', { campania_id: campaniaId, tabla_relacionada: 'viaje' }, function (data) {
                     renderCamposDinamicos(data);
                 });
             });

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::get('/logout', [LoginController::class, 'logout'])->middleware('ensure.lo
 Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('embarcaciones', EmbarcacionController::class)->except(['show']);
     Route::resource('campanias', CampaniaController::class)->except(['show']);
+    Route::get('ajax/campos-dinamicos', [CampaniaController::class, 'camposDinamicos']);
     Route::resource('puertos', PuertoController::class)->except(['show']);
     Route::resource('muelles', MuelleController::class)->except(['show']);
     Route::resource('tipoartes', TipoArteController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- Add `camposDinamicos` endpoint in `CampaniaController` to fetch and filter campaign fields
- Register `ajax/campos-dinamicos` route
- Update voyages form to load dynamic fields via the new AJAX endpoint

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689ca97715d88333a5ed5324bfbf74c6