### PR TITLE
Allow nullable tabla_multifinalitaria_id

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -68,7 +68,7 @@ class ViajeController extends Controller
             $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
                 ? ['required']
                 : ['nullable'];
-            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['required', 'integer'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['nullable', 'integer'];
         }
 
         $data = $request->validate($rules);
@@ -184,7 +184,7 @@ class ViajeController extends Controller
             $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
                 ? ['required']
                 : ['nullable'];
-            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['required', 'integer'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['nullable', 'integer'];
         }
 
         $data = $request->validate($rules);

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -182,7 +182,9 @@
                                 @default
                                     <input type="text" name="respuestas_multifinalitaria[{{ $loop->index }}][respuesta]" class="form-control" value="{{ $resp['respuesta'] ?? '' }}" {{ $required }}>
                             @endswitch
-                            <input type="hidden" name="respuestas_multifinalitaria[{{ $loop->index }}][tabla_multifinalitaria_id]" value="{{ $campo['id'] }}">
+                            @if(!empty($campo['id']))
+                                <input type="hidden" name="respuestas_multifinalitaria[{{ $loop->index }}][tabla_multifinalitaria_id]" value="{{ $campo['id'] }}">
+                            @endif
                             @if(isset($resp['id']))
                                 <input type="hidden" name="respuestas_multifinalitaria[{{ $loop->index }}][id]" value="{{ $resp['id'] }}">
                             @endif
@@ -855,7 +857,9 @@
                         default:
                             control = '<input type="text" class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]">';
                     }
-                    control += '<input type="hidden" name="respuestas_multifinalitaria[' + index + '][tabla_multifinalitaria_id]" value="' + campo.id + '">';
+                    if (campo.id != null) {
+                        control += '<input type="hidden" name="respuestas_multifinalitaria[' + index + '][tabla_multifinalitaria_id]" value="' + campo.id + '">';
+                    }
                     var col = $('<div class="col-md-4 mb-3"></div>');
                     col.append('<label class="form-label">' + (campo.nombre_pregunta || '') + '</label>');
                     col.append(control);


### PR DESCRIPTION
## Summary
- Relax validation for `tabla_multifinalitaria_id` to accept null
- Avoid sending empty `tabla_multifinalitaria_id` from dynamic form fields

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689cb4a529b08333838e2884ab17c756