### PR TITLE
feat: support dynamic captura fields via ajax

### DIFF
--- a/app/Http/Controllers/CapturaAjaxController.php
+++ b/app/Http/Controllers/CapturaAjaxController.php
@@ -28,9 +28,28 @@ class CapturaAjaxController extends Controller
         return response()->json($resp->json(), $resp->status());
     }
 
+    /**
+     * Crea una captura.
+     *
+     * Además de los campos estándar se aceptan campos dinámicos en el
+     * arreglo `respuestas_multifinalitaria`, donde cada elemento debe tener
+     * la forma `{"tabla_multifinalitaria_id": int, "respuesta": mixed, "id"?: int}`.
+     */
     public function store(Request $request)
     {
-        $data = $request->validate([
+        $viajeId = (int) $request->input('viaje_id');
+        $campos = [];
+        if ($viajeId) {
+            $respViaje = $this->apiService->get("/viajes/{$viajeId}");
+            if ($respViaje->successful()) {
+                $campaniaId = $respViaje->json()['campania_id'] ?? null;
+                if ($campaniaId) {
+                    $campos = $this->getCamposDinamicosCaptura((int) $campaniaId);
+                }
+            }
+        }
+
+        $rules = [
             'nombre_comun' => ['nullable', 'string'],
             'numero_individuos' => ['nullable', 'integer'],
             'peso_estimado' => ['nullable', 'numeric'],
@@ -42,16 +61,52 @@ class CapturaAjaxController extends Controller
             'tipo_numero_individuos' => ['nullable', 'string'],
             'tipo_peso' => ['nullable', 'string'],
             'estado_producto' => ['nullable', 'string'],
-        ]);
+        ];
+
+        foreach ($campos as $i => $campo) {
+            $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
+                ? ['required']
+                : ['nullable'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['nullable', 'integer'];
+            $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
+        }
+
+        $data = $request->validate($rules);
+
+        $campoMap = collect($campos)->keyBy('id');
+        $data['respuestas_multifinalitaria'] = collect($data['respuestas_multifinalitaria'] ?? [])
+            ->map(function ($resp) use ($campoMap) {
+                $id = $resp['tabla_multifinalitaria_id'] ?? null;
+                $campo = (array) $campoMap->get($id, []);
+                $campo['tabla_multifinalitaria_id'] = $campo['id'] ?? $id;
+                unset($campo['id']);
+
+                return array_merge($campo, [
+                    'id' => $resp['id'] ?? null,
+                    'respuesta' => $resp['respuesta'] ?? null,
+                    'tabla_relacionada_id' => null,
+                ]);
+            })
+            ->all();
 
         $resp = $this->apiService->post('/capturas', $data);
 
         return response()->json($resp->json(), $resp->status());
     }
 
+    /**
+     * Actualiza una captura existente.
+     *
+     * Se aceptan los mismos campos dinámicos descritos en `store`.
+     */
     public function update(Request $request, string $id)
     {
-        $data = $request->validate([
+        $respCaptura = $this->apiService->get("/capturas/{$id}");
+        $campos = $respCaptura->successful()
+            ? ($respCaptura->json()['respuestas_multifinalitaria'] ?? [])
+            : [];
+
+        $rules = [
             'nombre_comun' => ['nullable', 'string'],
             'numero_individuos' => ['nullable', 'integer'],
             'peso_estimado' => ['nullable', 'numeric'],
@@ -63,7 +118,32 @@ class CapturaAjaxController extends Controller
             'tipo_numero_individuos' => ['nullable', 'string'],
             'tipo_peso' => ['nullable', 'string'],
             'estado_producto' => ['nullable', 'string'],
-        ]);
+        ];
+
+        foreach ($campos as $i => $campo) {
+            $rules["respuestas_multifinalitaria.$i.respuesta"] = !empty($campo['requerido'])
+                ? ['required']
+                : ['nullable'];
+            $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['nullable', 'integer'];
+            $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
+        }
+
+        $data = $request->validate($rules);
+
+        $campoMap = collect($campos)->keyBy('tabla_multifinalitaria_id');
+        $data['respuestas_multifinalitaria'] = collect($data['respuestas_multifinalitaria'] ?? [])
+            ->map(function ($resp) use ($campoMap, $id) {
+                $campo = (array) $campoMap->get($resp['tabla_multifinalitaria_id'], []);
+                $campo['tabla_multifinalitaria_id'] = $campo['tabla_multifinalitaria_id']
+                    ?? $resp['tabla_multifinalitaria_id'];
+
+                return array_merge($campo, [
+                    'id' => $resp['id'] ?? ($campo['id'] ?? null),
+                    'respuesta' => $resp['respuesta'] ?? null,
+                    'tabla_relacionada_id' => (int) $id,
+                ]);
+            })
+            ->all();
 
         $resp = $this->apiService->put("/capturas/{$id}", $data);
 
@@ -75,6 +155,28 @@ class CapturaAjaxController extends Controller
         $resp = $this->apiService->delete("/capturas/{$id}");
 
         return response()->json($resp->json(), $resp->status());
+    }
+
+    private function getCamposDinamicosCaptura(int $campaniaId): array
+    {
+        $response = $this->apiService->get("/campanias/{$campaniaId}");
+        if (! $response->successful()) {
+            return [];
+        }
+
+        $campania = $response->json();
+        $campos = $campania['campos'] ?? [];
+
+        return collect($campos)
+            ->filter(fn($c) => ($c['tabla_relacionada'] ?? '') === 'captura')
+            ->map(function ($c) {
+                $c['opciones'] = is_array($c['opciones'] ?? null)
+                    ? json_encode($c['opciones'])
+                    : ($c['opciones'] ?? '[]');
+                return $c;
+            })
+            ->values()
+            ->all();
     }
 }
 

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1271,6 +1271,10 @@
                     tipo_peso: $('#tipo_peso').val(),
                     estado_producto: $('#estado_producto').val()
                 };
+                // Para campos dinámicos agregue un arreglo `respuestas_multifinalitaria`:
+                // payload.respuestas_multifinalitaria = [
+                //   { tabla_multifinalitaria_id: 1, respuesta: 'valor', id: null }
+                // ];
                 console.log(payload)
                 const url = id ? `${ajaxBase}/capturas/${id}` : `${ajaxBase}/capturas`;
                 const method = id ? 'PUT' : 'POST';


### PR DESCRIPTION
## Summary
- handle dynamic `respuestas_multifinalitaria` fields in AJAX controller
- document structure for dynamic capture fields on frontend

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689ce63a56b0833384217fa5c0e7ad42