### PR TITLE
Fix dynamic capture field submission

### DIFF
--- a/app/Http/Controllers/CapturaAjaxController.php
+++ b/app/Http/Controllers/CapturaAjaxController.php
@@ -71,6 +71,12 @@ class CapturaAjaxController extends Controller
             $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
         }
 
+        $request->merge([
+            'respuestas_multifinalitaria' => array_values(
+                $request->input('respuestas_multifinalitaria', [])
+            ),
+        ]);
+
         $data = $request->validate($rules);
 
         $campoMap = collect($campos)->keyBy('id');
@@ -127,6 +133,12 @@ class CapturaAjaxController extends Controller
             $rules["respuestas_multifinalitaria.$i.tabla_multifinalitaria_id"] = ['nullable', 'integer'];
             $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
         }
+
+        $request->merge([
+            'respuestas_multifinalitaria' => array_values(
+                $request->input('respuestas_multifinalitaria', [])
+            ),
+        ]);
 
         $data = $request->validate($rules);
 


### PR DESCRIPTION
## Summary
- Always include dynamic field responses when submitting capture form
- Reindex `respuestas_multifinalitaria` before validation to match expected indexes

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689cfac399648333af457ab8eb51b84d