### PR TITLE
Fix dynamic capture field submission

### DIFF
--- a/app/Http/Controllers/CapturaAjaxController.php
+++ b/app/Http/Controllers/CapturaAjaxController.php
@@ -61,6 +61,7 @@ class CapturaAjaxController extends Controller
             'tipo_numero_individuos' => ['nullable', 'string'],
             'tipo_peso' => ['nullable', 'string'],
             'estado_producto' => ['nullable', 'string'],
+            'respuestas_multifinalitaria' => ['array'],
         ];
 
         foreach ($campos as $i => $campo) {
@@ -71,10 +72,17 @@ class CapturaAjaxController extends Controller
             $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
         }
 
+        $request->merge([
+            'respuestas_multifinalitaria' => array_values(
+                $request->input('respuestas_multifinalitaria', [])
+            ),
+        ]);
+
         $data = $request->validate($rules);
+        $respuestas = $request->input('respuestas_multifinalitaria', []);
 
         $campoMap = collect($campos)->keyBy('id');
-        $data['respuestas_multifinalitaria'] = collect($data['respuestas_multifinalitaria'] ?? [])
+        $data['respuestas_multifinalitaria'] = collect($respuestas)
             ->map(function ($resp) use ($campoMap) {
                 $id = $resp['tabla_multifinalitaria_id'] ?? null;
                 $campo = (array) $campoMap->get($id, []);
@@ -118,6 +126,7 @@ class CapturaAjaxController extends Controller
             'tipo_numero_individuos' => ['nullable', 'string'],
             'tipo_peso' => ['nullable', 'string'],
             'estado_producto' => ['nullable', 'string'],
+            'respuestas_multifinalitaria' => ['array'],
         ];
 
         foreach ($campos as $i => $campo) {
@@ -128,10 +137,17 @@ class CapturaAjaxController extends Controller
             $rules["respuestas_multifinalitaria.$i.id"] = ['nullable', 'integer'];
         }
 
+        $request->merge([
+            'respuestas_multifinalitaria' => array_values(
+                $request->input('respuestas_multifinalitaria', [])
+            ),
+        ]);
+
         $data = $request->validate($rules);
+        $respuestas = $request->input('respuestas_multifinalitaria', []);
 
         $campoMap = collect($campos)->keyBy('tabla_multifinalitaria_id');
-        $data['respuestas_multifinalitaria'] = collect($data['respuestas_multifinalitaria'] ?? [])
+        $data['respuestas_multifinalitaria'] = collect($respuestas)
             ->map(function ($resp) use ($campoMap, $id) {
                 $campo = (array) $campoMap->get($resp['tabla_multifinalitaria_id'], []);
                 $campo['tabla_multifinalitaria_id'] = $campo['tabla_multifinalitaria_id']


### PR DESCRIPTION
## Summary
- Always include dynamic field responses when submitting capture form
- Reindex `respuestas_multifinalitaria` before validation to match expected indexes
- Preserve dynamic field responses during validation so backend forwards them to API

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689cfac399648333af457ab8eb51b84d