### PR TITLE
Ensure dynamic capture responses are sent in payload

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1347,7 +1347,7 @@
                 };
                 const respuestas = {};
                 $('#campos-dinamicos-captura')
-                    .find('[name$="[tabla_multifinalitaria_id]"]')
+                    .find('input[name*="[tabla_multifinalitaria_id]"]')
                     .each(function () {
                         const wrap = $(this).closest('.col-md-4');
                         const key = $(this).val();
@@ -1360,7 +1360,7 @@
                         respuestas[key] = item;
                     });
                 payload.respuestas_multifinalitaria = Object.values(respuestas);
-                console.log(payload)
+                console.log('Payload a enviar:', payload);
                 const url = id ? `${ajaxBase}/capturas/${id}` : `${ajaxBase}/capturas`;
                 const method = id ? 'PUT' : 'POST';
                 $.ajax({


### PR DESCRIPTION
## Summary
- Fix jQuery selector in capture form to match dynamic multifinalitaria inputs
- Log payload before sending to confirm multifinalitaria responses

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689e24f15ed48333b5d26b91415b5d48