### PR TITLE
Proxy external API calls through Laravel routes

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\JsonResponse;
+
+class ApiProxyController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function getEspecies(): JsonResponse
+    {
+        $resp = $this->apiService->get('/especies');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getTipoObservador(): JsonResponse
+    {
+        $resp = $this->apiService->get('/tipo-observador');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getTiposTripulante(): JsonResponse
+    {
+        $resp = $this->apiService->get('/tipos-tripulante');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getEstadosMarea(): JsonResponse
+    {
+        $resp = $this->apiService->get('/estados-marea');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getCondicionesMar(): JsonResponse
+    {
+        $resp = $this->apiService->get('/condiciones-mar');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getTiposInsumo(): JsonResponse
+    {
+        $resp = $this->apiService->get('/tipos-insumo');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getUnidadesInsumo(): JsonResponse
+    {
+        $resp = $this->apiService->get('/unidades-insumo');
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -938,7 +938,7 @@
             function cargarEspecies(selected = '') {
                 const select = $('#especie_id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/especies')
+                fetch('{{ route('api.especies') }}')
                     .then(response => response.json())
                     .then(data => {
                         data.forEach(e => {
@@ -952,7 +952,7 @@
             function cargarTiposObservador(selected = '') {
                 const select = $('#tipo_observador_id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/tipo-observador')
+                fetch('{{ route('api.tipo-observador') }}')
                     .then(response => response.json())
                     .then(data => {
                         data.forEach(t => {
@@ -966,7 +966,7 @@
             function cargarTiposTripulante(selected = '') {
                 const select = $('#tipo_tripulante_id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/tipos-tripulante')
+                fetch('{{ route('api.tipos-tripulante') }}')
                     .then(response => response.json())
                     .then(data => {
                         data.forEach(t => {
@@ -1051,7 +1051,7 @@
             function cargarEstadosMarea(selected = '') {
                 const select = $('#estado_marea_id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/estados-marea')
+                fetch('{{ route('api.estados-marea') }}')
                     .then(response => response.json())
                     .then(data => {
                         data.forEach(e => {
@@ -1065,7 +1065,7 @@
             function cargarCondicionesMar(selected = '') {
                 const select = $('#condicion_mar_id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/condiciones-mar')
+                fetch('{{ route('api.condiciones-mar') }}')
                     .then(response => response.json())
                     .then(data => {
                         data.forEach(c => {
@@ -1152,7 +1152,7 @@
 
             function cargarTiposInsumo(selected = '') {
                 const select = $('#tipo_insumo_id').empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/tipos-insumo')
+                fetch('{{ route('api.tipos-insumo') }}')
                     .then(r => r.json())
                     .then(data => {
                         data.forEach(t => {
@@ -1164,7 +1164,7 @@
 
             function cargarUnidadesInsumo(selected = '') {
                 const select = $('#unidad_insumo_id').empty().append('<option value="">Seleccione...</option>');
-                fetch('http://186.46.31.211:9090/isospam/unidades-insumo')
+                fetch('{{ route('api.unidades-insumo') }}')
                     .then(r => r.json())
                     .then(data => {
                         data.forEach(u => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ use App\Http\Controllers\FlotaController;
 use App\Http\Controllers\KpiController;
 use App\Http\Controllers\AlertasController;
 use App\Http\Controllers\ApiController;
+use App\Http\Controllers\ApiProxyController;
 use App\Http\Controllers\ParametroAmbientalAjaxController;
 use App\Http\Controllers\EconomiaInsumoAjaxController;
 
@@ -193,3 +194,12 @@ Route::get('/kpi/alertas', [AlertasController::class, 'index'])->name('kpi.alert
 Route::get('/api/esfuerzo', [ApiController::class, 'esfuerzo'])->name('api.esfuerzo');
 Route::get('/api/sitios', [ApiController::class, 'sitios'])->name('api.sitios');
 Route::get('/api/serie', [ApiController::class, 'serie'])->name('api.serie');
+
+// API proxy to external service
+Route::get('/api/especies', [ApiProxyController::class, 'getEspecies'])->name('api.especies');
+Route::get('/api/tipo-observador', [ApiProxyController::class, 'getTipoObservador'])->name('api.tipo-observador');
+Route::get('/api/tipos-tripulante', [ApiProxyController::class, 'getTiposTripulante'])->name('api.tipos-tripulante');
+Route::get('/api/estados-marea', [ApiProxyController::class, 'getEstadosMarea'])->name('api.estados-marea');
+Route::get('/api/condiciones-mar', [ApiProxyController::class, 'getCondicionesMar'])->name('api.condiciones-mar');
+Route::get('/api/tipos-insumo', [ApiProxyController::class, 'getTiposInsumo'])->name('api.tipos-insumo');
+Route::get('/api/unidades-insumo', [ApiProxyController::class, 'getUnidadesInsumo'])->name('api.unidades-insumo');


### PR DESCRIPTION
## Summary
- add ApiProxyController that forwards requests to external ISOSPAM API
- define named `/api` routes for species, observer types, crew types, tides, sea conditions, and insumo lookups
- update viajes form view to fetch data via new Laravel routes instead of hardcoded URLs

## Testing
- `composer test`
- `php artisan route:list --name=api.especies`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5c268c88333a375ff07296a2bb3