### PR TITLE
Use ApiProxy for form data

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -52,5 +52,17 @@ class ApiProxyController extends Controller
         $resp = $this->apiService->get('/unidades-insumo');
         return response()->json($resp->json(), $resp->status());
     }
+
+    public function getPersonas(): JsonResponse
+    {
+        $resp = $this->apiService->get('/personas');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getPersona(string $id): JsonResponse
+    {
+        $resp = $this->apiService->get("/personas/{$id}");
+        return response()->json($resp->json(), $resp->status());
+    }
 }
 

--- a/resources/views/capturas/form.blade.php
+++ b/resources/views/capturas/form.blade.php
@@ -95,7 +95,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const select = document.getElementById('especie_id');
     const selected = @json(old('especie_id', $captura['especie_id'] ?? ''));
 
-    fetch('http://186.46.31.211:9090/isospam/especies')
+    fetch('{{ route('api.especies') }}')
         .then(response => response.json())
         .then(data => {
             data.forEach(e => {

--- a/resources/views/economia-insumo/form.blade.php
+++ b/resources/views/economia-insumo/form.blade.php
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const selectedTipo = @json(old('tipo_insumo_id', $economia['tipo_insumo_id'] ?? ''));
     const selectedUnidad = @json(old('unidad_insumo_id', $economia['unidad_insumo_id'] ?? ''));
 
-    fetch('http://186.46.31.211:9090/isospam/tipos-insumo')
+    fetch('{{ route('api.tipos-insumo') }}')
         .then(r => r.json())
         .then(data => {
             data.forEach(t => {
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
 
-    fetch('http://186.46.31.211:9090/isospam/unidades-insumo')
+    fetch('{{ route('api.unidades-insumo') }}')
         .then(r => r.json())
         .then(data => {
             data.forEach(u => {

--- a/resources/views/observadores-viaje/form.blade.php
+++ b/resources/views/observadores-viaje/form.blade.php
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const tipoSelect = document.getElementById('tipo_observador_id');
     const personaSelect = $('#persona_idpersona');
     const selectedTipo = @json(old('tipo_observador_id', $observador['tipo_observador_id'] ?? ''));
-    fetch('http://186.46.31.211:9090/isospam/tipo-observador')
+    fetch('{{ route('api.tipo-observador') }}')
         .then(r => r.json())
         .then(data => {
             data.forEach(t => {
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     const selectedPersona = @json(old('persona_idpersona', $observador['persona_idpersona'] ?? ''));
     if (selectedPersona) {
-        fetch(`http://186.46.31.211:9090/isospam/personas/${selectedPersona}`)
+        fetch(`{{ route('api.personas') }}/${selectedPersona}`)
             .then(r => r.json())
             .then(p => {
                 const opt = new Option(`${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim(), p.idpersona, true, true);

--- a/resources/views/tripulantes-viaje/form.blade.php
+++ b/resources/views/tripulantes-viaje/form.blade.php
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const tipoSelect = document.getElementById('tipo_tripulante_id');
     const personaSelect = $('#persona_idpersona');
     const selectedTipo = @json(old('tipo_tripulante_id', $tripulante['tipo_tripulante_id'] ?? ''));
-    fetch('http://186.46.31.211:9090/isospam/tipos-tripulante')
+    fetch('{{ route('api.tipos-tripulante') }}')
         .then(r => r.json())
         .then(data => {
             data.forEach(t => {
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     const selectedPersona = @json(old('persona_idpersona', $tripulante['persona_idpersona'] ?? ''));
     if (selectedPersona) {
-        fetch(`http://186.46.31.211:9090/isospam/personas/${selectedPersona}`)
+        fetch(`{{ route('api.personas') }}/${selectedPersona}`)
             .then(r => r.json())
             .then(p => {
                 const opt = new Option(`${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim(), p.idpersona, true, true);

--- a/routes/web.php
+++ b/routes/web.php
@@ -203,3 +203,5 @@ Route::get('/api/estados-marea', [ApiProxyController::class, 'getEstadosMarea'])
 Route::get('/api/condiciones-mar', [ApiProxyController::class, 'getCondicionesMar'])->name('api.condiciones-mar');
 Route::get('/api/tipos-insumo', [ApiProxyController::class, 'getTiposInsumo'])->name('api.tipos-insumo');
 Route::get('/api/unidades-insumo', [ApiProxyController::class, 'getUnidadesInsumo'])->name('api.unidades-insumo');
+Route::get('/api/personas', [ApiProxyController::class, 'getPersonas'])->name('api.personas');
+Route::get('/api/personas/{id}', [ApiProxyController::class, 'getPersona'])->name('api.personas.show');


### PR DESCRIPTION
## Summary
- Add proxy methods for personas in ApiProxyController
- Register API routes for personas
- Replace hardcoded fetch calls in forms with controller routes

## Testing
- `php artisan test`
- `php artisan route:list | grep 'api.personas' -n`


------
https://chatgpt.com/codex/tasks/task_e_68a7f830e03c8333a9a14ec275cc044c