### PR TITLE
Add global loading spinner for form operations

### DIFF
--- a/resources/views/asignacionresponsable/form.blade.php
+++ b/resources/views/asignacionresponsable/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($asignacion) ? 'Editar' : 'Nueva' }} Asignación Responsable</h3>
 <form method="POST" action="{{ isset($asignacion) ? route('asignacionresponsable.update', $asignacion['id']) : route('asignacionresponsable.store') }}">

--- a/resources/views/campanias/form.blade.php
+++ b/resources/views/campanias/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($campania) ? 'Editar' : 'Nueva' }} Campaña</h3>
 <form method="POST" action="{{ isset($campania) ? route('campanias.update', $campania['id']) : route('campanias.store') }}">

--- a/resources/views/capturas/form.blade.php
+++ b/resources/views/capturas/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($captura) ? 'Editar' : 'Nueva' }} Captura</h3>
 <form method="POST" action="{{ isset($captura) ? route('capturas.update', $captura['id']) : route('capturas.store') }}">

--- a/resources/views/components/spinner.blade.php
+++ b/resources/views/components/spinner.blade.php
@@ -1,0 +1,19 @@
+<div class="spinner-overlay d-none">
+    <div class="spinner-border text-light" role="status">
+        <span class="sr-only">Loading...</span>
+    </div>
+</div>
+<style>
+    .spinner-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+</style>

--- a/resources/views/condicionesmar/form.blade.php
+++ b/resources/views/condicionesmar/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($condicion) ? 'Editar' : 'Nueva' }} Condición del Mar</h3>
 <form method="POST" action="{{ isset($condicion) ? route('condicionesmar.update', $condicion['id']) : route('condicionesmar.store') }}">

--- a/resources/views/economia-insumo/form.blade.php
+++ b/resources/views/economia-insumo/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($economia) ? 'Editar' : 'Nuevo' }} Economía de Insumo</h3>
 <form method="POST" action="{{ isset($economia) ? route('economia-insumo.update', $economia['id']) : route('economia-insumo.store') }}">

--- a/resources/views/embarcaciones/form.blade.php
+++ b/resources/views/embarcaciones/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($embarcacion) ? 'Editar' : 'Nueva' }} Embarcación</h3>
 <form method="POST" action="{{ isset($embarcacion) ? route('embarcaciones.update', $embarcacion['id']) : route('embarcaciones.store') }}">

--- a/resources/views/especies/form.blade.php
+++ b/resources/views/especies/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($especie) ? 'Editar' : 'Nueva' }} Especie</h3>
 <form method="POST" action="{{ isset($especie) ? route('especies.update', $especie['id']) : route('especies.store') }}">

--- a/resources/views/estadodesarrollogonadal/form.blade.php
+++ b/resources/views/estadodesarrollogonadal/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($estado) ? 'Editar' : 'Nuevo' }} Estado de Desarrollo Gonadal</h3>
 <form method="POST" action="{{ isset($estado) ? route('estadodesarrollogonadal.update', $estado['id']) : route('estadodesarrollogonadal.store') }}">

--- a/resources/views/estadosmarea/form.blade.php
+++ b/resources/views/estadosmarea/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($estado) ? 'Editar' : 'Nuevo' }} Estado de Marea</h3>
 <form method="POST" action="{{ isset($estado) ? route('estadosmarea.update', $estado['id']) : route('estadosmarea.store') }}">

--- a/resources/views/familias/form.blade.php
+++ b/resources/views/familias/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($familia) ? 'Editar' : 'Nueva' }} Familia</h3>
 <form method="POST" action="{{ isset($familia) ? route('familias.update', $familia['id']) : route('familias.store') }}">

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -14,6 +14,7 @@
 </head>
 
 <body class="hold-transition sidebar-mini layout-fixed dark-mode">
+    @yield('spinner')
     <div class="wrapper">
         <!-- Navbar -->
         <nav class="main-header navbar navbar-expand navbar-dark">
@@ -494,6 +495,18 @@
                 }
             });
         }
+
+        $(document).on('submit', 'form', function () {
+            $('.spinner-overlay').removeClass('d-none');
+        });
+
+        $(document).ajaxComplete(function () {
+            $('.spinner-overlay').addClass('d-none');
+        });
+
+        $(window).on('pageshow', function () {
+            $('.spinner-overlay').addClass('d-none');
+        });
     </script>
     @yield('scripts')
 </body>

--- a/resources/views/materialesmalla/form.blade.php
+++ b/resources/views/materialesmalla/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($materialmalla) ? 'Editar' : 'Nuevo' }} Material de Malla</h3>
 <form method="POST" action="{{ isset($materialmalla) ? route('materialesmalla.update', $materialmalla['id']) : route('materialesmalla.store') }}">

--- a/resources/views/menus/form.blade.php
+++ b/resources/views/menus/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($menu) ? 'Editar' : 'Nuevo' }} Menú</h3>
 <form method="POST" action="{{ isset($menu) ? route('menus.update', $menu['id']) : route('menus.store') }}">

--- a/resources/views/muelles/form.blade.php
+++ b/resources/views/muelles/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($muelle) ? 'Editar' : 'Nuevo' }} Muelle</h3>
 <form method="POST" action="{{ isset($muelle) ? route('muelles.update', $muelle['id']) : route('muelles.store') }}">

--- a/resources/views/observadores-viaje/form.blade.php
+++ b/resources/views/observadores-viaje/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($observador) ? 'Editar' : 'Nuevo' }} Observador</h3>
 <form method="POST" action="{{ isset($observador) ? route('observadores-viaje.update', $observador['id']) : route('observadores-viaje.store') }}">

--- a/resources/views/organizacionpesquera/form.blade.php
+++ b/resources/views/organizacionpesquera/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($organizacion) ? 'Editar' : 'Nueva' }} Organización Pesquera</h3>
 <form method="POST" action="{{ isset($organizacion) ? route('organizacionpesquera.update', $organizacion['id']) : route('organizacionpesquera.store') }}">

--- a/resources/views/personas/form.blade.php
+++ b/resources/views/personas/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <div class="card">
     <div class="card-header">

--- a/resources/views/puertos/form.blade.php
+++ b/resources/views/puertos/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($puerto) ? 'Editar' : 'Nuevo' }} Puerto</h3>
 <form method="POST" action="{{ isset($puerto) ? route('puertos.update', $puerto['id']) : route('puertos.store') }}">

--- a/resources/views/roles/form.blade.php
+++ b/resources/views/roles/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($rol) ? 'Editar' : 'Nuevo' }} Rol</h3>
 <form method="POST" action="{{ isset($rol) ? route('roles.update', $rol['id']) : route('roles.store') }}">

--- a/resources/views/rolmenu/form.blade.php
+++ b/resources/views/rolmenu/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($item) ? 'Editar' : 'Nueva' }} Asignación Menú a Rol</h3>
 <form method="POST" action="{{ isset($item) ? route('rolmenu.update', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) : route('rolmenu.store') }}">

--- a/resources/views/rolpersona/form.blade.php
+++ b/resources/views/rolpersona/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>Asignar Rol a Persona</h3>
 <form method="POST" action="{{ route('rolpersona.store') }}">

--- a/resources/views/sitios/form.blade.php
+++ b/resources/views/sitios/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($sitio) ? 'Editar' : 'Nuevo' }} Sitio</h3>
 <form method="POST" action="{{ isset($sitio) ? route('sitios.update', $sitio['id']) : route('sitios.store') }}">

--- a/resources/views/tipoanzuelos/form.blade.php
+++ b/resources/views/tipoanzuelos/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipoanzuelo) ? 'Editar' : 'Nuevo' }} Tipo de Anzuelo</h3>
 <form method="POST" action="{{ isset($tipoanzuelo) ? route('tipoanzuelos.update', $tipoanzuelo['id']) : route('tipoanzuelos.store') }}">

--- a/resources/views/tipoartes/form.blade.php
+++ b/resources/views/tipoartes/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipoarte) ? 'Editar' : 'Nuevo' }} Tipo de Arte</h3>
 <form method="POST" action="{{ isset($tipoarte) ? route('tipoartes.update', $tipoarte['id']) : route('tipoartes.store') }}">

--- a/resources/views/tipoembarcacion/form.blade.php
+++ b/resources/views/tipoembarcacion/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipoembarcacion) ? 'Editar' : 'Nuevo' }} Tipo de Embarcación</h3>
 <form method="POST" action="{{ isset($tipoembarcacion) ? route('tipoembarcaciones.update', $tipoembarcacion['id']) : route('tipoembarcaciones.store') }}">

--- a/resources/views/tipomotor/form.blade.php
+++ b/resources/views/tipomotor/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipomotor) ? 'Editar' : 'Nuevo' }} Tipo de Motor</h3>
 <form method="POST" action="{{ isset($tipomotor) ? route('tipomotores.update', $tipomotor['id']) : route('tipomotores.store') }}">

--- a/resources/views/tipoobservador/form.blade.php
+++ b/resources/views/tipoobservador/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipoobservador) ? 'Editar' : 'Nuevo' }} Tipo de Observador</h3>
 <form method="POST" action="{{ isset($tipoobservador) ? route('tipoobservador.update', $tipoobservador['id']) : route('tipoobservador.store') }}">

--- a/resources/views/tiposinsumo/form.blade.php
+++ b/resources/views/tiposinsumo/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($insumo) ? 'Editar' : 'Nuevo' }} Tipo de Insumo</h3>
 <form method="POST" action="{{ isset($insumo) ? route('tiposinsumo.update', $insumo['id']) : route('tiposinsumo.store') }}">

--- a/resources/views/tipotripulantes/form.blade.php
+++ b/resources/views/tipotripulantes/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tipotripulante) ? 'Editar' : 'Nuevo' }} Tipo de Tripulante</h3>
 <form method="POST" action="{{ isset($tipotripulante) ? route('tipotripulantes.update', $tipotripulante['id']) : route('tipotripulantes.store') }}">

--- a/resources/views/tripulantes-viaje/form.blade.php
+++ b/resources/views/tripulantes-viaje/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($tripulante) ? 'Editar' : 'Nuevo' }} Tripulante</h3>
 <form method="POST" action="{{ isset($tripulante) ? route('tripulantes-viaje.update', $tripulante['id']) : route('tripulantes-viaje.store') }}">

--- a/resources/views/unidadesinsumo/form.blade.php
+++ b/resources/views/unidadesinsumo/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($unidad) ? 'Editar' : 'Nueva' }} Unidad de Insumo</h3>
 <form method="POST" action="{{ isset($unidad) ? route('unidadesinsumo.update', $unidad['id']) : route('unidadesinsumo.store') }}">

--- a/resources/views/unidadlongitud/form.blade.php
+++ b/resources/views/unidadlongitud/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($unidad) ? 'Editar' : 'Nueva' }} Unidad de Longitud</h3>
 <form method="POST" action="{{ isset($unidad) ? route('unidadlongitud.update', $unidad['id']) : route('unidadlongitud.store') }}">

--- a/resources/views/unidadprofundidad/form.blade.php
+++ b/resources/views/unidadprofundidad/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($unidad) ? 'Editar' : 'Nuevo' }} Unidad de Profundidad</h3>
 <form method="POST" action="{{ isset($unidad) ? route('unidadprofundidad.update', $unidad['id']) : route('unidadprofundidad.store') }}">

--- a/resources/views/unidadventa/form.blade.php
+++ b/resources/views/unidadventa/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
 <h3>{{ isset($unidad) ? 'Editar' : 'Nueva' }} Unidad de Venta</h3>
 <form method="POST" action="{{ isset($unidad) ? route('unidadventa.update', $unidad['id']) : route('unidadventa.store') }}">

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.dashboard')
 
+@section('spinner')
+    <x-spinner />
+@endsection
+
+
 @section('content')
     <form id="viaje-form" method="POST" action="{{ isset($viaje) ? route('viajes.update', $viaje['id']) : route('viajes.store') }}">
         @csrf


### PR DESCRIPTION
## Summary
- add reusable spinner component
- integrate spinner into dashboard layout with jQuery show/hide logic
- include spinner section in all form views

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a94c85b20c833398f0fe58de3b778f