### PR TITLE
Use SweetAlert2 for flash messages

### DIFF
--- a/resources/views/asignacionresponsable/index.blade.php
+++ b/resources/views/asignacionresponsable/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('asignacionresponsable.create', $organizacionId ? ['organizacion_pesquera_id' => $organizacionId] : []) }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/campanias/index.blade.php
+++ b/resources/views/campanias/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('campanias.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/capturas/index.blade.php
+++ b/resources/views/capturas/index.blade.php
@@ -12,10 +12,14 @@
     @endif
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/condicionesmar/index.blade.php
+++ b/resources/views/condicionesmar/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('condicionesmar.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/economia-insumo/index.blade.php
+++ b/resources/views/economia-insumo/index.blade.php
@@ -12,10 +12,14 @@
     @endif
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/embarcaciones/index.blade.php
+++ b/resources/views/embarcaciones/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('embarcaciones.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/especies/index.blade.php
+++ b/resources/views/especies/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('especies.create', $familiaId ? ['familia_id' => $familiaId] : []) }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/estadodesarrollogonadal/index.blade.php
+++ b/resources/views/estadodesarrollogonadal/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('estadodesarrollogonadal.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/estadosmarea/index.blade.php
+++ b/resources/views/estadosmarea/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('estadosmarea.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/familias/index.blade.php
+++ b/resources/views/familias/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('familias.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -450,6 +450,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script>
         $.ajaxSetup({
             headers: {

--- a/resources/views/materialesmalla/index.blade.php
+++ b/resources/views/materialesmalla/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('materialesmalla.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/muelles/index.blade.php
+++ b/resources/views/muelles/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('muelles.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/observadores-viaje/index.blade.php
+++ b/resources/views/observadores-viaje/index.blade.php
@@ -12,10 +12,14 @@
     @endif
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/organizacionpesquera/index.blade.php
+++ b/resources/views/organizacionpesquera/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('organizacionpesquera.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/personas/index.blade.php
+++ b/resources/views/personas/index.blade.php
@@ -20,10 +20,14 @@
             </div>
         </form>
         @if(session('success'))
-            <div class="alert alert-success">{{ session('success') }}</div>
+            <script>
+                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+            </script>
         @endif
         @if($errors->any())
-            <div class="alert alert-danger">{{ $errors->first() }}</div>
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+            </script>
         @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">

--- a/resources/views/puertos/index.blade.php
+++ b/resources/views/puertos/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('puertos.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/roles/index.blade.php
+++ b/resources/views/roles/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('roles.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/rolmenu/index.blade.php
+++ b/resources/views/rolmenu/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('rolmenu.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/rolpersona/index.blade.php
+++ b/resources/views/rolpersona/index.blade.php
@@ -23,10 +23,14 @@
     </div>
 </form>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/sitios/index.blade.php
+++ b/resources/views/sitios/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('sitios.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipoanzuelos/index.blade.php
+++ b/resources/views/tipoanzuelos/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipoanzuelos.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipoartes/index.blade.php
+++ b/resources/views/tipoartes/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipoartes.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipoembarcacion/index.blade.php
+++ b/resources/views/tipoembarcacion/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipoembarcaciones.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipomotor/index.blade.php
+++ b/resources/views/tipomotor/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipomotores.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipoobservador/index.blade.php
+++ b/resources/views/tipoobservador/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipoobservador.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tiposinsumo/index.blade.php
+++ b/resources/views/tiposinsumo/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tiposinsumo.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tipotripulantes/index.blade.php
+++ b/resources/views/tipotripulantes/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('tipotripulantes.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/tripulantes-viaje/index.blade.php
+++ b/resources/views/tripulantes-viaje/index.blade.php
@@ -12,10 +12,14 @@
     @endif
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/unidadesinsumo/index.blade.php
+++ b/resources/views/unidadesinsumo/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('unidadesinsumo.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/unidadlongitud/index.blade.php
+++ b/resources/views/unidadlongitud/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('unidadlongitud.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/unidadprofundidad/index.blade.php
+++ b/resources/views/unidadprofundidad/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('unidadprofundidad.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/unidadventa/index.blade.php
+++ b/resources/views/unidadventa/index.blade.php
@@ -10,10 +10,14 @@
     <a href="{{ route('unidadventa.create') }}" class="btn btn-primary">Nueva</a>
 </div>
 @if(session('success'))
-    <div class="alert alert-success">{{ session('success') }}</div>
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
 @endif
 @if($errors->any())
-    <div class="alert alert-danger">{{ $errors->first() }}</div>
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 <table class="table table-dark table-striped">
     <thead>

--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -25,10 +25,14 @@
             </div>
         </form>
         @if(session('success'))
-            <div class="alert alert-success">{{ session('success') }}</div>
+            <script>
+                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+            </script>
         @endif
         @if($errors->any())
-            <div class="alert alert-danger">{{ $errors->first() }}</div>
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+            </script>
         @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">


### PR DESCRIPTION
## Summary
- Add SweetAlert2 library to dashboard layout
- Show success and error messages via SweetAlert in all index views

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68aa692dbac48333be81be0f8b226b72