### PR TITLE
Use SweetAlert for form messages

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -135,10 +135,18 @@
                     </div>
                 </div>
                 @if(session('success'))
-                    <div class="alert alert-success">{{ session('success') }}</div>
+                    <script>
+                        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+                    </script>
                 @endif
-                @if($errors->any())
-                    <div class="alert alert-danger">{{ $errors->first() }}</div>
+                @if(session('error'))
+                    <script>
+                        Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+                    </script>
+                @elseif($errors->any())
+                    <script>
+                        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+                    </script>
                 @endif
             </div>
         </div>

--- a/resources/views/viajes/mis-por-finalizar.blade.php
+++ b/resources/views/viajes/mis-por-finalizar.blade.php
@@ -22,10 +22,18 @@
             </div>
         </form>
         @if(session('success'))
-            <div class="alert alert-success">{{ session('success') }}</div>
+            <script>
+                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+            </script>
         @endif
-        @if($errors->any())
-            <div class="alert alert-danger">{{ $errors->first() }}</div>
+        @if(session('error'))
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+            </script>
+        @elseif($errors->any())
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+            </script>
         @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">

--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -7,10 +7,18 @@
     </div>
     <div class="card-body">
         @if(session('success'))
-            <div class="alert alert-success">{{ session('success') }}</div>
+            <script>
+                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+            </script>
         @endif
-        @if($errors->any())
-            <div class="alert alert-danger">{{ $errors->first() }}</div>
+        @if(session('error'))
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+            </script>
+        @elseif($errors->any())
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+            </script>
         @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">


### PR DESCRIPTION
## Summary
- replace Bootstrap alerts with SweetAlert in viajes views
- display session and validation errors using SweetAlert

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68aa6c08f8348333beba2791527a8e01