### PR TITLE
refactor: move SweetAlert scripts to scripts section

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -134,20 +134,6 @@
                             class="form-control">{{ old('observaciones', $viaje['observaciones'] ?? '') }}</textarea>
                     </div>
                 </div>
-                @if(session('success'))
-                    <script>
-                        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-                    </script>
-                @endif
-                @if(session('error'))
-                    <script>
-                        Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
-                    </script>
-                @elseif($errors->any())
-                    <script>
-                        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-                    </script>
-                @endif
             </div>
         </div>
 
@@ -704,6 +690,20 @@
 @endsection
 
 @section('scripts')
+    @if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+    @if(session('error'))
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+        </script>
+    @elseif($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
     <script>
         $(function () {
             // Validación de fechas y horas de zarpe y arribo

--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -24,16 +24,6 @@
                 </div>
             </div>
         </form>
-        @if(session('success'))
-            <script>
-                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-            </script>
-        @endif
-        @if($errors->any())
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-            </script>
-        @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">
     <thead>
@@ -75,4 +65,17 @@
         </div>
     </div>
 </div>
+@endsection
+
+@section('scripts')
+    @if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+    @if($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
 @endsection

--- a/resources/views/viajes/mis-por-finalizar.blade.php
+++ b/resources/views/viajes/mis-por-finalizar.blade.php
@@ -21,20 +21,6 @@
                 </div>
             </div>
         </form>
-        @if(session('success'))
-            <script>
-                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-            </script>
-        @endif
-        @if(session('error'))
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
-            </script>
-        @elseif($errors->any())
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-            </script>
-        @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">
                 <thead>
@@ -74,23 +60,37 @@
 @endsection
 
 @section('scripts')
-<script>
-$(function () {
-    $('#digitador-select').select2({
-        width: '100%',
-        placeholder: 'Seleccione digitador...',
-        allowClear: true,
-        ajax: {
-            url: "{{ route('ajax.personas') }}",
-            dataType: 'json',
-            delay: 250,
-            data: params => ({ filtro: params.term, rol: 'CTF' }),
-            processResults: data => ({
-                results: $.map(data, p => ({ id: p.idpersona, text: `${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim() }))
-            }),
-            cache: true
-        }
-    });
-});
-</script>
+    @if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+    @if(session('error'))
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+        </script>
+    @elseif($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
+    <script>
+        $(function () {
+            $('#digitador-select').select2({
+                width: '100%',
+                placeholder: 'Seleccione digitador...',
+                allowClear: true,
+                ajax: {
+                    url: "{{ route('ajax.personas') }}",
+                    dataType: 'json',
+                    delay: 250,
+                    data: params => ({ filtro: params.term, rol: 'CTF' }),
+                    processResults: data => ({
+                        results: $.map(data, p => ({ id: p.idpersona, text: `${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim() }))
+                    }),
+                    cache: true
+                }
+            });
+        });
+    </script>
 @endsection

--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -6,20 +6,6 @@
         <h3 class="card-title mb-0">Viajes pendientes</h3>
     </div>
     <div class="card-body">
-        @if(session('success'))
-            <script>
-                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-            </script>
-        @endif
-        @if(session('error'))
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
-            </script>
-        @elseif($errors->any())
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-            </script>
-        @endif
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">
                 <thead>
@@ -60,4 +46,21 @@
         </div>
     </div>
 </div>
+@endsection
+
+@section('scripts')
+    @if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+    @if(session('error'))
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+        </script>
+    @elseif($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
 @endsection


### PR DESCRIPTION
## Summary
- move inline Swal.fire alerts to dedicated scripts sections in viajes views
- ensure dashboard layout loads SweetAlert2 before yielding view scripts

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7176da0c83338d7786a4935f1dd3