### PR TITLE
Refactor SweetAlert script placement

### DIFF
--- a/resources/views/asignacionresponsable/index.blade.php
+++ b/resources/views/asignacionresponsable/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Asignaciones de Responsable @if($organizacion) de {{ $organizacion['nombre'] ?? '' }} @endif</h3>
     <a href="{{ route('asignacionresponsable.create', $organizacionId ? ['organizacion_pesquera_id' => $organizacionId] : []) }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -52,5 +44,18 @@
 </table>
 @if($organizacionId)
     <a href="{{ route('organizacionpesquera.index') }}" class="btn btn-secondary mt-2">Volver a Organizaciones</a>
+@endif
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 @endsection

--- a/resources/views/campanias/index.blade.php
+++ b/resources/views/campanias/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Campañas</h3>
     <a href="{{ route('campanias.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -46,4 +38,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/capturas/index.blade.php
+++ b/resources/views/capturas/index.blade.php
@@ -11,16 +11,8 @@
         <a href="{{ route('capturas.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nueva</a>
     @endif
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -63,4 +55,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/condicionesmar/index.blade.php
+++ b/resources/views/condicionesmar/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Condiciones del Mar</h3>
     <a href="{{ route('condicionesmar.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/economia-insumo/index.blade.php
+++ b/resources/views/economia-insumo/index.blade.php
@@ -11,16 +11,8 @@
         <a href="{{ route('economia-insumo.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nuevo</a>
     @endif
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -51,3 +43,15 @@
 </table>
 @endsection
 
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
+@endsection

--- a/resources/views/embarcaciones/index.blade.php
+++ b/resources/views/embarcaciones/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Embarcaciones</h3>
     <a href="{{ route('embarcaciones.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -48,4 +40,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/especies/index.blade.php
+++ b/resources/views/especies/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Especies @if($familia) de {{ $familia['nombre'] ?? '' }} @endif</h3>
     <a href="{{ route('especies.create', $familiaId ? ['familia_id' => $familiaId] : []) }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -46,5 +38,18 @@
 </table>
 @if($familiaId)
     <a href="{{ route('familias.index') }}" class="btn btn-secondary mt-2">Volver a Familias</a>
+@endif
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
 @endif
 @endsection

--- a/resources/views/estadodesarrollogonadal/index.blade.php
+++ b/resources/views/estadodesarrollogonadal/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Estados Desarrollo Gonadal</h3>
     <a href="{{ route('estadodesarrollogonadal.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/estadosmarea/index.blade.php
+++ b/resources/views/estadosmarea/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Estados de Marea</h3>
     <a href="{{ route('estadosmarea.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/familias/index.blade.php
+++ b/resources/views/familias/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Familias</h3>
     <a href="{{ route('familias.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -43,4 +35,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/materialesmalla/index.blade.php
+++ b/resources/views/materialesmalla/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Materiales de Malla</h3>
     <a href="{{ route('materialesmalla.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Menús</h3>
     <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -48,4 +40,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/muelles/index.blade.php
+++ b/resources/views/muelles/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Muelles</h3>
     <a href="{{ route('muelles.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/observadores-viaje/index.blade.php
+++ b/resources/views/observadores-viaje/index.blade.php
@@ -11,16 +11,8 @@
         <a href="{{ route('observadores-viaje.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nuevo</a>
     @endif
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -49,3 +41,15 @@
 </table>
 @endsection
 
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
+@endsection

--- a/resources/views/organizacionpesquera/index.blade.php
+++ b/resources/views/organizacionpesquera/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Organizaciones Pesqueras</h3>
     <a href="{{ route('organizacionpesquera.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -46,4 +38,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/personas/index.blade.php
+++ b/resources/views/personas/index.blade.php
@@ -19,16 +19,8 @@
                 </div>
             </div>
         </form>
-        @if(session('success'))
-            <script>
-                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-            </script>
-        @endif
-        @if($errors->any())
-            <script>
-                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-            </script>
-        @endif
+        
+        
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">
     <thead>
@@ -69,3 +61,15 @@
 </div>
 @endsection
 
+@section('scripts')
+@if(session('success'))
+            <script>
+                Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+            </script>
+        @endif
+@if($errors->any())
+            <script>
+                Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+            </script>
+        @endif
+@endsection

--- a/resources/views/puertos/index.blade.php
+++ b/resources/views/puertos/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Puertos</h3>
     <a href="{{ route('puertos.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/roles/index.blade.php
+++ b/resources/views/roles/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Roles</h3>
     <a href="{{ route('roles.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -44,4 +36,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/rolmenu/index.blade.php
+++ b/resources/views/rolmenu/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Menús por Rol</h3>
     <a href="{{ route('rolmenu.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -46,4 +38,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/rolpersona/index.blade.php
+++ b/resources/views/rolpersona/index.blade.php
@@ -22,16 +22,8 @@
         </div>
     </div>
 </form>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -54,4 +46,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/sitios/index.blade.php
+++ b/resources/views/sitios/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Sitios</h3>
     <a href="{{ route('sitios.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipoanzuelos/index.blade.php
+++ b/resources/views/tipoanzuelos/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Anzuelo</h3>
     <a href="{{ route('tipoanzuelos.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipoartes/index.blade.php
+++ b/resources/views/tipoartes/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Arte</h3>
     <a href="{{ route('tipoartes.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -44,4 +36,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipoembarcacion/index.blade.php
+++ b/resources/views/tipoembarcacion/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Embarcación</h3>
     <a href="{{ route('tipoembarcaciones.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipomotor/index.blade.php
+++ b/resources/views/tipomotor/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Motor</h3>
     <a href="{{ route('tipomotores.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -44,4 +36,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipoobservador/index.blade.php
+++ b/resources/views/tipoobservador/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Observador</h3>
     <a href="{{ route('tipoobservador.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tiposinsumo/index.blade.php
+++ b/resources/views/tiposinsumo/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Insumo</h3>
     <a href="{{ route('tiposinsumo.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tipotripulantes/index.blade.php
+++ b/resources/views/tipotripulantes/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Tipos de Tripulante</h3>
     <a href="{{ route('tipotripulantes.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/tripulantes-viaje/index.blade.php
+++ b/resources/views/tripulantes-viaje/index.blade.php
@@ -11,16 +11,8 @@
         <a href="{{ route('tripulantes-viaje.create', ['viaje_id' => $viajeId]) }}" class="btn btn-primary">Nuevo</a>
     @endif
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -47,4 +39,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/unidadesinsumo/index.blade.php
+++ b/resources/views/unidadesinsumo/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Unidades de Insumo</h3>
     <a href="{{ route('unidadesinsumo.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -44,4 +36,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/unidadlongitud/index.blade.php
+++ b/resources/views/unidadlongitud/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Unidades de Longitud</h3>
     <a href="{{ route('unidadlongitud.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/unidadprofundidad/index.blade.php
+++ b/resources/views/unidadprofundidad/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Unidades de Profundidad</h3>
     <a href="{{ route('unidadprofundidad.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -44,4 +36,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/unidadventa/index.blade.php
+++ b/resources/views/unidadventa/index.blade.php
@@ -9,16 +9,8 @@
     <h3>Unidades de Venta</h3>
     <a href="{{ route('unidadventa.create') }}" class="btn btn-primary">Nueva</a>
 </div>
-@if(session('success'))
-    <script>
-        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-    </script>
-@endif
-@if($errors->any())
-    <script>
-        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-    </script>
-@endif
+
+
 <table class="table table-dark table-striped">
     <thead>
         <tr>
@@ -42,4 +34,17 @@
     @endforeach
     </tbody>
 </table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
 @endsection

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -689,20 +689,8 @@
 @endsection
 
 @section('scripts')
-    @if(session('success'))
-        <script>
-            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-        </script>
-    @endif
-    @if(session('error'))
-        <script>
-            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
-        </script>
-    @elseif($errors->any())
-        <script>
-            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-        </script>
-    @endif
+    
+    
     <script>
         function mostrarErrorCaptura(mensaje) {
             Swal.fire({ icon: 'error', title: 'Error', text: mensaje });
@@ -1501,4 +1489,21 @@
             }
         });
     </script>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+@if(session('error'))
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+        </script>
+    @elseif($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
 @endsection

--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -68,12 +68,17 @@
 @endsection
 
 @section('scripts')
-    @if(session('success'))
+    
+    
+@endsection
+
+@section('scripts')
+@if(session('success'))
         <script>
             Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
         </script>
     @endif
-    @if($errors->any())
+@if($errors->any())
         <script>
             Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
         </script>

--- a/resources/views/viajes/mis-por-finalizar.blade.php
+++ b/resources/views/viajes/mis-por-finalizar.blade.php
@@ -60,20 +60,8 @@
 @endsection
 
 @section('scripts')
-    @if(session('success'))
-        <script>
-            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
-        </script>
-    @endif
-    @if(session('error'))
-        <script>
-            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
-        </script>
-    @elseif($errors->any())
-        <script>
-            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
-        </script>
-    @endif
+    
+    
     <script>
         $(function () {
             $('#digitador-select').select2({
@@ -93,4 +81,21 @@
             });
         });
     </script>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+        <script>
+            Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+        </script>
+    @endif
+@if(session('error'))
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
+        </script>
+    @elseif($errors->any())
+        <script>
+            Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+        </script>
+    @endif
 @endsection

--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -49,12 +49,17 @@
 @endsection
 
 @section('scripts')
-    @if(session('success'))
+    
+    
+@endsection
+
+@section('scripts')
+@if(session('success'))
         <script>
             Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
         </script>
     @endif
-    @if(session('error'))
+@if(session('error'))
         <script>
             Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
         </script>


### PR DESCRIPTION
## Summary
- Move inline SweetAlert success/error snippets into a dedicated `@section('scripts')` across views
- Verify dashboard layout yields page scripts after including SweetAlert2 library

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68aaad623fd8833387a9f3e76300c213