### PR TITLE
Fix duplicate scripts section in trips index view

### DIFF
--- a/resources/views/viajes/index.blade.php
+++ b/resources/views/viajes/index.blade.php
@@ -66,19 +66,13 @@
     </div>
 </div>
 @endsection
-
 @section('scripts')
-    
-    
-@endsection
-
-@section('scripts')
-@if(session('success'))
+    @if(session('success'))
         <script>
             Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
         </script>
     @endif
-@if($errors->any())
+    @if($errors->any())
         <script>
             Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
         </script>


### PR DESCRIPTION
## Summary
- remove redundant scripts section from trips index
- keep SweetAlert logic for success and error messages

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68aabd60c6008333b94223b748aa7b92