### PR TITLE
feat: manage fishing site for captures

### DIFF
--- a/app/Http/Controllers/SitioPescaAjaxController.php
+++ b/app/Http/Controllers/SitioPescaAjaxController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class SitioPescaAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $resp = $this->apiService->get('/sitios-pesca', $request->query());
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'captura_id' => ['required', 'integer'],
+            'nombre' => ['nullable', 'string'],
+            'latitud' => ['nullable'],
+            'longitud' => ['nullable'],
+        ]);
+
+        // Validate uniqueness of captura_id
+        $existing = $this->apiService->get('/sitios-pesca', ['captura_id' => $data['captura_id']]);
+        if ($existing->successful() && !empty($existing->json())) {
+            return response()->json([
+                'message' => 'The given data was invalid.',
+                'errors' => [
+                    'captura_id' => ['Ya existe un sitio para esta captura.'],
+                ],
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $resp = $this->apiService->post('/sitios-pesca', $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'captura_id' => ['required', 'integer'],
+            'nombre' => ['nullable', 'string'],
+            'latitud' => ['nullable'],
+            'longitud' => ['nullable'],
+        ]);
+
+        $resp = $this->apiService->put("/sitios-pesca/{$id}", $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ use App\Http\Controllers\ObservadorViajeController;
 use App\Http\Controllers\ObservadorViajeAjaxController;
 use App\Http\Controllers\TripulanteViajeController;
 use App\Http\Controllers\TripulanteViajeAjaxController;
+use App\Http\Controllers\SitioPescaAjaxController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ReportesOperativosController;
 use App\Http\Controllers\CapturasController;
@@ -101,6 +102,10 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('ajax/capturas', [CapturaAjaxController::class, 'store'])->name('ajax.capturas.store');
     Route::put('ajax/capturas/{id}', [CapturaAjaxController::class, 'update'])->name('ajax.capturas.update');
     Route::delete('ajax/capturas/{id}', [CapturaAjaxController::class, 'destroy'])->name('ajax.capturas.destroy');
+
+    Route::get('isospam/sitios-pesca', [SitioPescaAjaxController::class, 'index']);
+    Route::post('isospam/sitios-pesca', [SitioPescaAjaxController::class, 'store']);
+    Route::put('isospam/sitios-pesca/{id}', [SitioPescaAjaxController::class, 'update']);
 
     Route::resource('tripulantes-viaje', TripulanteViajeController::class)->except(['show']);
     Route::get('ajax/tripulantes-viaje', [TripulanteViajeAjaxController::class, 'index'])->name('ajax.tripulantes-viaje');


### PR DESCRIPTION
## Summary
- add controller and routes to proxy fishing site endpoints
- fetch and save fishing site data from capture form

## Testing
- `composer test` *(fails: the application returns a successful response expected 404 but got 302)*

------
https://chatgpt.com/codex/tasks/task_e_68ab978a6ea88333a52fde1ec182e7b7