### PR TITLE
Mostrar datos de sitio de pesca al abrir modal de captura

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1307,6 +1307,33 @@
                 $('#tipo_peso').val(data.tipo_peso || '');
                 $('#estado_producto').val(data.estado_producto || '');
                 renderCamposDinamicosCaptura([]);
+
+                const sitioCard = $('#sitio-pesca-card');
+                const sitioNombre = $('#sitio-nombre');
+                const sitioLatitud = $('#sitio-latitud');
+                const sitioLongitud = $('#sitio-longitud');
+
+                sitioNombre.val('');
+                sitioLatitud.val('');
+                sitioLongitud.val('');
+                sitioCard.removeClass('d-none').show();
+
+                if (data.id) {
+                    fetch(`${ajaxBase}/sitios-pesca?captura_id=${data.id}`)
+                        .then(r => r.ok ? r.json() : Promise.reject(r))
+                        .then(sitios => {
+                            if (Array.isArray(sitios) && sitios.length > 0) {
+                                const s = sitios[0];
+                                sitioNombre.val(s.nombre || '');
+                                sitioLatitud.val(s.latitud || '');
+                                sitioLongitud.val(s.longitud || '');
+                            }
+                        })
+                        .catch(err => {
+                            console.error('Error al cargar sitio de pesca:', err);
+                            alert('Error al cargar sitio de pesca');
+                        });
+                }
                 if (data.id) {
                     const campos = (data.respuestas_multifinalitaria || []).map(r => ({
                         id: r.tabla_multifinalitaria_id,


### PR DESCRIPTION
## Summary
- Mostrar siempre la tarjeta de sitio de pesca en el modal de captura
- Consultar y precargar datos del sitio de pesca cuando existe un `captura_id`
- Registrar errores de la API sin bloquear la apertura del modal

## Testing
- `./vendor/bin/phpunit` *(fails: ExampleTest::test_the_application_returns_a_successful_response)*

------
https://chatgpt.com/codex/tasks/task_e_68ababe577748333ade9897da3568c2a