### PR TITLE
Switch SitioPesca routes to ajax prefix

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -103,9 +103,9 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::put('ajax/capturas/{id}', [CapturaAjaxController::class, 'update'])->name('ajax.capturas.update');
     Route::delete('ajax/capturas/{id}', [CapturaAjaxController::class, 'destroy'])->name('ajax.capturas.destroy');
 
-    Route::get('isospam/sitios-pesca', [SitioPescaAjaxController::class, 'index']);
-    Route::post('isospam/sitios-pesca', [SitioPescaAjaxController::class, 'store']);
-    Route::put('isospam/sitios-pesca/{id}', [SitioPescaAjaxController::class, 'update']);
+    Route::get('ajax/sitios-pesca', [SitioPescaAjaxController::class, 'index']);
+    Route::post('ajax/sitios-pesca', [SitioPescaAjaxController::class, 'store']);
+    Route::put('ajax/sitios-pesca/{id}', [SitioPescaAjaxController::class, 'update']);
 
     Route::resource('tripulantes-viaje', TripulanteViajeController::class)->except(['show']);
     Route::get('ajax/tripulantes-viaje', [TripulanteViajeAjaxController::class, 'index'])->name('ajax.tripulantes-viaje');


### PR DESCRIPTION
## Summary
- use `ajax/sitios-pesca` prefix for SitioPesca Ajax routes

## Testing
- `php artisan route:clear`
- `./vendor/bin/phpunit` *(fails: Expected response status code [404] but received 302)*
- `curl -i http://127.0.0.1:8000/ajax/sitios-pesca?captura_id=1` *(500 Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68abb071d7ac8333a8e6d34229d9e756