### PR TITLE
Add proxy endpoints for depth units and sites

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -53,6 +53,18 @@ class ApiProxyController extends Controller
         return response()->json($resp->json(), $resp->status());
     }
 
+    public function getUnidadesProfundidad(): JsonResponse
+    {
+        $resp = $this->apiService->get('/unidad-profundidad');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getSitios(): JsonResponse
+    {
+        $resp = $this->apiService->get('/sitios');
+        return response()->json($resp->json(), $resp->status());
+    }
+
     public function getPersonas(): JsonResponse
     {
         $resp = $this->apiService->get('/personas');

--- a/resources/views/capturas/form.blade.php
+++ b/resources/views/capturas/form.blade.php
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function loadUnidades(selected = '') {
         unidad.innerHTML = '<option value="">Seleccione...</option>';
-        fetch(`${ajaxBase}/unidades-profundidad`)
+        fetch("{{ route('api.unidades-profundidad') }}")
             .then(r => r.json())
             .then(data => {
                 data.forEach(u => {
@@ -183,7 +183,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function loadSitios(selected = '') {
         sitioSelect.innerHTML = '<option value="">Seleccione...</option>';
-        fetch(`${ajaxBase}/sitios`)
+        fetch("{{ route('api.sitios') }}")
             .then(r => r.json())
             .then(data => {
                 sitiosCache = Array.isArray(data) ? data : [];

--- a/resources/views/reportes/zonas/sitios.blade.php
+++ b/resources/views/reportes/zonas/sitios.blade.php
@@ -12,7 +12,7 @@
 const map = L.map('map').setView([-0.7,-80.1], 7);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18}).addTo(map);
 
-fetch(`{{ route('api.sitios') }}`)
+fetch(`{{ route('api.sitios.reporte') }}`)
   .then(r=>r.json())
   .then(rows=>{
     rows.forEach(r=>{

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1076,7 +1076,7 @@
             function cargarUnidadesProfundidad(selected = '') {
                 const select = $('#sitio-unidad-profundidad');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch(`${ajaxBase}/unidades-profundidad`)
+                fetch("{{ route('api.unidades-profundidad') }}")
                     .then(r => r.json())
                     .then(data => {
                         data.forEach(u => {
@@ -1091,7 +1091,7 @@
             function cargarSitios(selected = '') {
                 const select = $('#sitio-id');
                 select.empty().append('<option value="">Seleccione...</option>');
-                fetch(`${ajaxBase}/sitios`)
+                fetch("{{ route('api.sitios') }}")
                     .then(r => r.json())
                     .then(data => {
                         sitiosCache = Array.isArray(data) ? data : [];

--- a/routes/web.php
+++ b/routes/web.php
@@ -197,7 +197,7 @@ Route::get('/kpi/alertas', [AlertasController::class, 'index'])->name('kpi.alert
 
 // API para mapas/gráficas
 Route::get('/api/esfuerzo', [ApiController::class, 'esfuerzo'])->name('api.esfuerzo');
-Route::get('/api/sitios', [ApiController::class, 'sitios'])->name('api.sitios');
+Route::get('/api/sitios-reporte', [ApiController::class, 'sitios'])->name('api.sitios.reporte');
 Route::get('/api/serie', [ApiController::class, 'serie'])->name('api.serie');
 
 // API proxy to external service
@@ -208,5 +208,7 @@ Route::get('/api/estados-marea', [ApiProxyController::class, 'getEstadosMarea'])
 Route::get('/api/condiciones-mar', [ApiProxyController::class, 'getCondicionesMar'])->name('api.condiciones-mar');
 Route::get('/api/tipos-insumo', [ApiProxyController::class, 'getTiposInsumo'])->name('api.tipos-insumo');
 Route::get('/api/unidades-insumo', [ApiProxyController::class, 'getUnidadesInsumo'])->name('api.unidades-insumo');
+Route::get('/api/unidades-profundidad', [ApiProxyController::class, 'getUnidadesProfundidad'])->name('api.unidades-profundidad');
+Route::get('/api/sitios', [ApiProxyController::class, 'getSitios'])->name('api.sitios');
 Route::get('/api/personas', [ApiProxyController::class, 'getPersonas'])->name('api.personas');
 Route::get('/api/personas/{id}', [ApiProxyController::class, 'getPersona'])->name('api.personas.show');


### PR DESCRIPTION
## Summary
- proxy API endpoints for depth units and sites
- expose new routes and update JS selects to consume them
- rename existing sites report route to avoid conflict

## Testing
- `composer test` *(fails: Expected response status code [404] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68abbb503724833398774151adf97aca