### PR TITLE
Load site and depth units once in capture modal

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1396,13 +1396,13 @@
                 sitioProfundidad.val('');
                 sitioUnidad.val('');
                 sitioCard.removeClass('d-none').show();
-                cargarUnidadesProfundidad();
-                cargarSitios();
 
                 if (data.id) {
                     fetch(`${ajaxBase}/sitios-pesca?captura_id=${data.id}`)
                         .then(r => r.ok ? r.json() : Promise.reject(r))
                         .then(sitios => {
+                            let unidadId = '';
+                            let sitioSeleccionado = '';
                             if (Array.isArray(sitios) && sitios.length > 0) {
                                 const s = sitios[0];
                                 sitioRegistroId.val(s.id || '');
@@ -1411,14 +1411,21 @@
                                 sitioLatitud.val(s.latitud || '');
                                 sitioLongitud.val(s.longitud || '');
                                 sitioProfundidad.val(s.profundidad || '');
-                                cargarUnidadesProfundidad(s.unidad_profundidad_id || '');
-                                cargarSitios(s.sitio_id || '');
+                                unidadId = s.unidad_profundidad_id || '';
+                                sitioSeleccionado = s.sitio_id || '';
                             }
+                            cargarUnidadesProfundidad(unidadId);
+                            cargarSitios(sitioSeleccionado);
                         })
                         .catch(err => {
                             console.error('Error al cargar sitio de pesca:', err);
                             alert('Error al cargar sitio de pesca');
+                            cargarUnidadesProfundidad('');
+                            cargarSitios('');
                         });
+                } else {
+                    cargarUnidadesProfundidad('');
+                    cargarSitios('');
                 }
                 if (data.id) {
                     const campos = (data.respuestas_multifinalitaria || []).map(r => ({


### PR DESCRIPTION
## Summary
- Avoid duplicate requests when opening capture modal by deferring depth unit and site loading until after site data is fetched
- Call loaders with selected IDs or blanks depending on presence of capture data

## Testing
- ❌ `composer test` (1 failed, 1 passed)


------
https://chatgpt.com/codex/tasks/task_e_68abc57c88008333b8887daf0b0486d4