### PR TITLE
Ensure CSRF token included in fetch requests

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1030,6 +1030,7 @@
 
             const ajaxBase = "{{ url('ajax') }}";
             const viajeId = "{{ $viaje['id'] ?? 'null' }}";
+            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
             function cargarEspecies(selected = '') {
                 const select = $('#especie_id');
@@ -1569,7 +1570,11 @@
                 try {
                     const capturaResp = await fetch(url, {
                         method,
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken
+                        },
+                        credentials: 'same-origin',
                         body: JSON.stringify(payload)
                     });
 
@@ -1604,7 +1609,11 @@
 
                     const sitioResp = await fetch(sitioUrl, {
                         method: sitioMethod,
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken
+                        },
+                        credentials: 'same-origin',
                         body: JSON.stringify(sitioPayload)
                     });
 


### PR DESCRIPTION
## Summary
- Include CSRF token constant for `viajes` form script
- Attach CSRF header and same-origin credentials to capture and fishing site `fetch` requests

## Testing
- `composer test` *(fails: Expected response status code [404] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68abcbdc291c8333b12e6f78c52dbd1a