### PR TITLE
Mostrar spinner durante operaciones de captura

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1486,9 +1486,11 @@
             }
 
             function editarCaptura(id) {
+                $('.spinner-overlay').removeClass('d-none');
                 $.ajax({
                     url: `${ajaxBase}/capturas/${id}`,
-                    success: data => abrirModal(data)
+                    success: data => abrirModal(data),
+                    complete: () => $('.spinner-overlay').addClass('d-none')
                 });
             }
 
@@ -1581,6 +1583,7 @@
                 const url = id ? `${ajaxBase}/capturas/${id}` : `${ajaxBase}/capturas`;
                 const method = id ? 'PUT' : 'POST';
 
+                $('.spinner-overlay').removeClass('d-none');
                 try {
                     const capturaResp = await fetch(url, {
                         method,
@@ -1653,6 +1656,8 @@
                 } catch (err) {
                     console.error(err);
                     mostrarErrorCaptura('Error al guardar la captura');
+                } finally {
+                    $('.spinner-overlay').addClass('d-none');
                 }
             });
 


### PR DESCRIPTION
## Summary
- Controla el spinner al editar una captura
- Muestra y oculta el spinner al guardar capturas y sitios de pesca

## Testing
- `composer test` *(fails: Expected response status code [404] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68abd79a3df48333b916703cbb4ccfbe