### PR TITLE
Add ArtePescaAjaxController for fishing gear endpoints

### DIFF
--- a/app/Http/Controllers/ArtePescaAjaxController.php
+++ b/app/Http/Controllers/ArtePescaAjaxController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class ArtePescaAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $resp = $this->apiService->get('/artes-pesca', $request->query());
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'captura_id' => ['required', 'integer'],
+            'tipo_arte_id' => ['required', 'integer'],
+            'lineas_madre' => ['nullable', 'integer'],
+            'anzuelos' => ['nullable', 'integer'],
+            'tamanio_anzuelo_pulg' => ['nullable', 'numeric'],
+            'tipo_anzuelo_id' => ['nullable', 'integer'],
+            'largo_red_m' => ['nullable', 'numeric'],
+            'alto_red_m' => ['nullable', 'numeric'],
+            'material_malla_id' => ['nullable', 'integer'],
+            'ojo_malla_cm' => ['nullable', 'numeric'],
+            'diametro' => ['nullable', 'numeric'],
+            'carnadaviva' => ['nullable', 'boolean'],
+            'especiecarnada' => ['nullable', 'string'],
+        ]);
+
+        $resp = $this->apiService->post('/artes-pesca', [
+            'captura_id' => $data['captura_id'],
+            'tipo_arte_id' => $data['tipo_arte_id'],
+            'lineas_madre' => $data['lineas_madre'] ?? null,
+            'anzuelos' => $data['anzuelos'] ?? null,
+            'tamanio_anzuelo_pulg' => $data['tamanio_anzuelo_pulg'] ?? null,
+            'tipo_anzuelo_id' => $data['tipo_anzuelo_id'] ?? null,
+            'largo_red_m' => $data['largo_red_m'] ?? null,
+            'alto_red_m' => $data['alto_red_m'] ?? null,
+            'material_malla_id' => $data['material_malla_id'] ?? null,
+            'ojo_malla_cm' => $data['ojo_malla_cm'] ?? null,
+            'diametro' => $data['diametro'] ?? null,
+            'carnadaviva' => $data['carnadaviva'] ?? null,
+            'especiecarnada' => $data['especiecarnada'] ?? null,
+        ]);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'captura_id' => ['required', 'integer'],
+            'tipo_arte_id' => ['required', 'integer'],
+            'lineas_madre' => ['nullable', 'integer'],
+            'anzuelos' => ['nullable', 'integer'],
+            'tamanio_anzuelo_pulg' => ['nullable', 'numeric'],
+            'tipo_anzuelo_id' => ['nullable', 'integer'],
+            'largo_red_m' => ['nullable', 'numeric'],
+            'alto_red_m' => ['nullable', 'numeric'],
+            'material_malla_id' => ['nullable', 'integer'],
+            'ojo_malla_cm' => ['nullable', 'numeric'],
+            'diametro' => ['nullable', 'numeric'],
+            'carnadaviva' => ['nullable', 'boolean'],
+            'especiecarnada' => ['nullable', 'string'],
+        ]);
+
+        $resp = $this->apiService->put("/artes-pesca/{$id}", [
+            'captura_id' => $data['captura_id'],
+            'tipo_arte_id' => $data['tipo_arte_id'],
+            'lineas_madre' => $data['lineas_madre'] ?? null,
+            'anzuelos' => $data['anzuelos'] ?? null,
+            'tamanio_anzuelo_pulg' => $data['tamanio_anzuelo_pulg'] ?? null,
+            'tipo_anzuelo_id' => $data['tipo_anzuelo_id'] ?? null,
+            'largo_red_m' => $data['largo_red_m'] ?? null,
+            'alto_red_m' => $data['alto_red_m'] ?? null,
+            'material_malla_id' => $data['material_malla_id'] ?? null,
+            'ojo_malla_cm' => $data['ojo_malla_cm'] ?? null,
+            'diametro' => $data['diametro'] ?? null,
+            'carnadaviva' => $data['carnadaviva'] ?? null,
+            'especiecarnada' => $data['especiecarnada'] ?? null,
+        ]);
+
+        return response()->json($resp->json(), $resp->status());
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ use App\Http\Controllers\ObservadorViajeAjaxController;
 use App\Http\Controllers\TripulanteViajeController;
 use App\Http\Controllers\TripulanteViajeAjaxController;
 use App\Http\Controllers\SitioPescaAjaxController;
+use App\Http\Controllers\ArtePescaAjaxController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ReportesOperativosController;
 use App\Http\Controllers\CapturasController;
@@ -106,6 +107,10 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::get('ajax/sitios-pesca', [SitioPescaAjaxController::class, 'index']);
     Route::post('ajax/sitios-pesca', [SitioPescaAjaxController::class, 'store']);
     Route::put('ajax/sitios-pesca/{id}', [SitioPescaAjaxController::class, 'update']);
+
+    Route::get('ajax/artes-pesca', [ArtePescaAjaxController::class, 'index']);
+    Route::post('ajax/artes-pesca', [ArtePescaAjaxController::class, 'store']);
+    Route::put('ajax/artes-pesca/{id}', [ArtePescaAjaxController::class, 'update']);
 
     Route::resource('tripulantes-viaje', TripulanteViajeController::class)->except(['show']);
     Route::get('ajax/tripulantes-viaje', [TripulanteViajeAjaxController::class, 'index'])->name('ajax.tripulantes-viaje');


### PR DESCRIPTION
## Summary
- create ArtePescaAjaxController handling artes de pesca via ApiService
- register AJAX routes for fishing gear CRUD

## Testing
- `composer test` (fails: Failed opening required '/workspace/ISOSPAM/vendor/autoload.php')

------
https://chatgpt.com/codex/tasks/task_e_68abe50907cc8333bc08f4b53a2e988a