### PR TITLE
Add API proxy methods for gear metadata

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -41,6 +41,24 @@ class ApiProxyController extends Controller
         return response()->json($resp->json(), $resp->status());
     }
 
+    public function getTiposArte(): JsonResponse
+    {
+        $resp = $this->apiService->get('/tipos-arte');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getTiposAnzuelo(): JsonResponse
+    {
+        $resp = $this->apiService->get('/tipos-anzuelo');
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function getMaterialesMalla(): JsonResponse
+    {
+        $resp = $this->apiService->get('/materiales-malla');
+        return response()->json($resp->json(), $resp->status());
+    }
+
     public function getTiposInsumo(): JsonResponse
     {
         $resp = $this->apiService->get('/tipos-insumo');

--- a/routes/web.php
+++ b/routes/web.php
@@ -211,6 +211,9 @@ Route::get('/api/tipo-observador', [ApiProxyController::class, 'getTipoObservado
 Route::get('/api/tipos-tripulante', [ApiProxyController::class, 'getTiposTripulante'])->name('api.tipos-tripulante');
 Route::get('/api/estados-marea', [ApiProxyController::class, 'getEstadosMarea'])->name('api.estados-marea');
 Route::get('/api/condiciones-mar', [ApiProxyController::class, 'getCondicionesMar'])->name('api.condiciones-mar');
+Route::get('/api/tipos-arte', [ApiProxyController::class, 'getTiposArte'])->name('api.tipos-arte');
+Route::get('/api/tipos-anzuelo', [ApiProxyController::class, 'getTiposAnzuelo'])->name('api.tipos-anzuelo');
+Route::get('/api/materiales-malla', [ApiProxyController::class, 'getMaterialesMalla'])->name('api.materiales-malla');
 Route::get('/api/tipos-insumo', [ApiProxyController::class, 'getTiposInsumo'])->name('api.tipos-insumo');
 Route::get('/api/unidades-insumo', [ApiProxyController::class, 'getUnidadesInsumo'])->name('api.unidades-insumo');
 Route::get('/api/unidades-profundidad', [ApiProxyController::class, 'getUnidadesProfundidad'])->name('api.unidades-profundidad');


### PR DESCRIPTION
## Summary
- add proxy methods for art types, hook types and net materials
- register routes for new proxy endpoints

## Testing
- `php artisan route:clear`
- `php artisan test` *(fails: Expected response status code [404] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68abed7fa5648333863baf48345e7410