### PR TITLE
Add economic sale data handling to capture modal

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -71,6 +71,12 @@ class ApiProxyController extends Controller
         return response()->json($resp->json(), $resp->status());
     }
 
+    public function getUnidadesVenta(): JsonResponse
+    {
+        $resp = $this->apiService->get('/unidad-venta');
+        return response()->json($resp->json(), $resp->status());
+    }
+
     public function getUnidadesProfundidad(): JsonResponse
     {
         $resp = $this->apiService->get('/unidad-profundidad');

--- a/app/Http/Controllers/EconomiaVentaAjaxController.php
+++ b/app/Http/Controllers/EconomiaVentaAjaxController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class EconomiaVentaAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(Request $request)
+    {
+        $capturaId = $request->query('captura_id');
+        $resp = $this->apiService->get('/economia-ventas', ['captura_id' => $capturaId]);
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function show(string $id)
+    {
+        $resp = $this->apiService->get("/economia-ventas/{$id}");
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'vendido_a' => ['required', 'string'],
+            'destino' => ['required', 'string'],
+            'precio' => ['required', 'numeric'],
+            'unidad_venta_id' => ['required', 'integer'],
+            'captura_id' => ['required', 'integer'],
+        ]);
+        $resp = $this->apiService->post('/economia-ventas', $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'vendido_a' => ['required', 'string'],
+            'destino' => ['required', 'string'],
+            'precio' => ['required', 'numeric'],
+            'unidad_venta_id' => ['required', 'integer'],
+            'captura_id' => ['required', 'integer'],
+        ]);
+        $resp = $this->apiService->put("/economia-ventas/{$id}", $data);
+        return response()->json($resp->json(), $resp->status());
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ use App\Http\Controllers\ApiController;
 use App\Http\Controllers\ApiProxyController;
 use App\Http\Controllers\ParametroAmbientalAjaxController;
 use App\Http\Controllers\EconomiaInsumoAjaxController;
+use App\Http\Controllers\EconomiaVentaAjaxController;
 
 Route::get('/', function () {
     return view('home');
@@ -139,6 +140,11 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::put('ajax/economia-insumo/{id}', [EconomiaInsumoAjaxController::class, 'update'])->name('ajax.economia-insumo.update');
     Route::delete('ajax/economia-insumo/{id}', [EconomiaInsumoAjaxController::class, 'destroy'])->name('ajax.economia-insumo.destroy');
 
+    Route::get('ajax/economia-ventas', [EconomiaVentaAjaxController::class, 'index'])->name('ajax.economia-ventas');
+    Route::get('ajax/economia-ventas/{id}', [EconomiaVentaAjaxController::class, 'show'])->name('ajax.economia-ventas.show');
+    Route::post('ajax/economia-ventas', [EconomiaVentaAjaxController::class, 'store'])->name('ajax.economia-ventas.store');
+    Route::put('ajax/economia-ventas/{id}', [EconomiaVentaAjaxController::class, 'update'])->name('ajax.economia-ventas.update');
+
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);
     Route::get('rolmenu/{idrol}/{idmenu}/edit', [RolMenuController::class, 'edit'])->name('rolmenu.edit');
@@ -216,6 +222,7 @@ Route::get('/api/tipos-anzuelo', [ApiProxyController::class, 'getTiposAnzuelo'])
 Route::get('/api/materiales-malla', [ApiProxyController::class, 'getMaterialesMalla'])->name('api.materiales-malla');
 Route::get('/api/tipos-insumo', [ApiProxyController::class, 'getTiposInsumo'])->name('api.tipos-insumo');
 Route::get('/api/unidades-insumo', [ApiProxyController::class, 'getUnidadesInsumo'])->name('api.unidades-insumo');
+Route::get('/api/unidades-venta', [ApiProxyController::class, 'getUnidadesVenta'])->name('api.unidades-venta');
 Route::get('/api/unidades-profundidad', [ApiProxyController::class, 'getUnidadesProfundidad'])->name('api.unidades-profundidad');
 Route::get('/api/sitios', [ApiProxyController::class, 'getSitios'])->name('api.sitios');
 Route::get('/api/personas', [ApiProxyController::class, 'getPersonas'])->name('api.personas');


### PR DESCRIPTION
## Summary
- Capture form now includes "Dato económico" card with fields for sale information
- Load and save economic sale data via new JS helpers and EconomiaVentaAjaxController
- Added API proxy and routes for unidad de venta listings

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ad3644f660833390199391a5b750db