### PR TITLE
Display spinner while saving biological data

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1855,6 +1855,7 @@
                 const url = id ? `${ajaxBase}/datos-biologicos/${id}` : `${ajaxBase}/datos-biologicos`;
                 const method = id ? 'PUT' : 'POST';
                 console.log(payload)
+                $('.spinner-overlay').removeClass('d-none');
                 const resp = await fetch(url, {
                     method,
                     headers: {
@@ -1863,7 +1864,7 @@
                     },
                     credentials: 'same-origin',
                     body: JSON.stringify(payload)
-                });
+                }).finally(() => $('.spinner-overlay').addClass('d-none'));
                 if (resp.ok) {
                     $('#dato-biologico-modal').modal('hide');
                     cargarDatosBiologicos(capturaId);


### PR DESCRIPTION
## Summary
- show spinner when submitting biological data in voyage form
- hide spinner when request finishes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0ec08b7c8333bfe751bb23fc9563