### PR TITLE
Prevent spinner from persisting when adding Dato Biologico

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1839,6 +1839,7 @@
 
         $('#dato-biologico-form').on('submit', async function (e) {
             e.preventDefault();
+            e.stopPropagation();
             $('.spinner-overlay').removeClass('d-none');
             try {
                 const id = $('#dato-biologico-id').val();


### PR DESCRIPTION
## Summary
- stop event propagation in DatoBiologico form submit handler so spinner closes correctly

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae220927048333829d106fca2915e0