### PR TITLE
feat: add captura file upload ajax endpoints

### DIFF
--- a/app/Http/Controllers/ArchivoCapturaAjaxController.php
+++ b/app/Http/Controllers/ArchivoCapturaAjaxController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+
+class ArchivoCapturaAjaxController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index(int $capturaId)
+    {
+        $resp = $this->apiService->get("/capturas/{$capturaId}/archivos");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function store(Request $request, int $capturaId)
+    {
+        $request->validate([
+            'archivos' => ['required', 'array'],
+            'archivos.*' => ['file'],
+        ]);
+
+        $resp = $this->apiService->postFiles(
+            "/capturas/{$capturaId}/archivos",
+            $request->file('archivos'),
+            $request->except('archivos')
+        );
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    public function destroy(int $id)
+    {
+        $resp = $this->apiService->delete("/archivos/{$id}");
+
+        return response()->json($resp->json(), $resp->status());
+    }
+}
+

--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -54,6 +54,21 @@ class ApiService
         return $this->withToken()->post($url, $data);
     }
 
+    public function postFiles(string $url, array $files, array $data = [])
+    {
+        $request = $this->withToken()->asMultipart();
+
+        foreach ($files as $name => $file) {
+            $request = $request->attach(
+                is_string($name) ? $name : 'archivos[]',
+                fopen($file->getRealPath(), 'r'),
+                $file->getClientOriginalName()
+            );
+        }
+
+        return $request->post($url, $data);
+    }
+
     public function put(string $url, array $data = [])
     {
         return $this->withToken()->put($url, $data);

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1964,7 +1964,7 @@
                 $('#archivos-captura-table tbody').empty();
                 return Promise.resolve();
             }
-            return fetch(`/isospam/capturas/${capturaId}/archivos`)
+            return fetch(`/ajax/capturas/${capturaId}/archivos`)
                 .then(r => r.ok ? r.json() : [])
                 .then(data => {
                     const tbody = $('#archivos-captura-table tbody').empty();
@@ -2000,7 +2000,7 @@
                 return;
             }
             if (!confirm('¿Eliminar archivo?')) return;
-            fetch(`/isospam/archivos/${id}`, {
+            fetch(`/ajax/archivos/${id}`, {
                 method: 'DELETE',
                 headers: { 'X-CSRF-TOKEN': csrfToken },
                 credentials: 'same-origin'
@@ -2018,7 +2018,7 @@
             if (capturaId) {
                 const formData = new FormData();
                 Array.from(files).forEach(f => formData.append('archivos[]', f));
-                fetch(`/isospam/capturas/${capturaId}/archivos-form`, {
+                fetch(`/ajax/capturas/${capturaId}/archivos`, {
                     method: 'POST',
                     headers: { 'X-CSRF-TOKEN': csrfToken },
                     body: formData,
@@ -2560,7 +2560,7 @@
                     const file = $(tr).data('file');
                     const fd = new FormData();
                     fd.append('archivos[]', file);
-                    await fetch(`/isospam/capturas/${capturaId}/archivos-form`, {
+                    await fetch(`/ajax/capturas/${capturaId}/archivos`, {
                         method: 'POST',
                         headers: { 'X-CSRF-TOKEN': csrfToken },
                         body: fd,

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,7 @@ use App\Http\Controllers\ParametroAmbientalAjaxController;
 use App\Http\Controllers\EconomiaInsumoAjaxController;
 use App\Http\Controllers\EconomiaVentaAjaxController;
 use App\Http\Controllers\DatoBiologicoAjaxController;
+use App\Http\Controllers\ArchivoCapturaAjaxController;
 
 Route::get('/', function () {
     return view('home');
@@ -105,6 +106,9 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('ajax/capturas', [CapturaAjaxController::class, 'store'])->name('ajax.capturas.store');
     Route::put('ajax/capturas/{id}', [CapturaAjaxController::class, 'update'])->name('ajax.capturas.update');
     Route::delete('ajax/capturas/{id}', [CapturaAjaxController::class, 'destroy'])->name('ajax.capturas.destroy');
+    Route::get('ajax/capturas/{captura}/archivos', [ArchivoCapturaAjaxController::class, 'index']);
+    Route::post('ajax/capturas/{captura}/archivos', [ArchivoCapturaAjaxController::class, 'store']);
+    Route::delete('ajax/archivos/{archivo}', [ArchivoCapturaAjaxController::class, 'destroy']);
 
     Route::get('ajax/datos-biologicos', [DatoBiologicoAjaxController::class, 'index']);
     Route::get('ajax/datos-biologicos/{id}', [DatoBiologicoAjaxController::class, 'show']);


### PR DESCRIPTION
## Summary
- add `postFiles` to ApiService to support multipart file uploads
- introduce ArchivoCapturaAjaxController with index/store/destroy
- wire new AJAX routes and update front-end fetch calls

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68afe830bab88333a82609215502dda7