### PR TITLE
Validate file uploads and API responses

### DIFF
--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -60,13 +60,19 @@ class ApiService
 
         foreach ($files as $name => $file) {
             $request = $request->attach(
-                is_string($name) ? $name : 'archivos[]',
+                is_string($name) ? $name : 'archivos',
                 fopen($file->getRealPath(), 'r'),
                 $file->getClientOriginalName()
             );
         }
 
-        return $request->post($url, $data);
+        $response = $request->post($url, $data);
+
+        if ($response->failed()) {
+            $response->throw();
+        }
+
+        return $response;
     }
 
     public function put(string $url, array $data = [])


### PR DESCRIPTION
## Summary
- Remove array notation from file upload key to correctly submit attachments
- Ensure file upload requests throw on failed responses before returning

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aff49973c48333abe622380579cba0