### PR TITLE
Handle file upload errors

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -2560,12 +2560,16 @@
                     const file = $(tr).data('file');
                     const fd = new FormData();
                     fd.append('archivos', file);
-                    await fetch(`/ajax/capturas/${capturaId}/archivos`, {
+                    const respArch = await fetch(`/ajax/capturas/${capturaId}/archivos`, {
                         method: 'POST',
                         headers: { 'X-CSRF-TOKEN': csrfToken },
                         body: fd,
                         credentials: 'same-origin'
                     });
+                    if (!respArch.ok) {
+                        mostrarErrorCaptura('Error al subir el archivo');
+                        return;
+                    }
                 }
                 cargarDatosBiologicos(capturaId);
                 cargarArchivos(capturaId);


### PR DESCRIPTION
## Summary
- Validate file upload requests and surface errors to the user

## Testing
- `./vendor/bin/phpunit`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aff679109883338452071492b246ea