### PR TITLE
Handle multiple capture file uploads

### DIFF
--- a/app/Http/Controllers/ArchivoCapturaAjaxController.php
+++ b/app/Http/Controllers/ArchivoCapturaAjaxController.php
@@ -21,13 +21,16 @@ class ArchivoCapturaAjaxController extends Controller
     public function store(Request $request, int $capturaId)
     {
         $request->validate([
-            'archivos' => ['required', 'array'],
+            'archivos' => ['required'],
             'archivos.*' => ['file'],
         ]);
 
+        $files = $request->file('archivos');
+        $files = is_array($files) ? $files : [$files];
+
         $resp = $this->apiService->postFiles(
             "/capturas/{$capturaId}/archivos-form",
-            $request->file('archivos'),
+            $files,
             $request->except('archivos')
         );
 

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -2017,7 +2017,7 @@
             }
             if (capturaId) {
                 const formData = new FormData();
-                Array.from(files).forEach(f => formData.append('archivos', f));
+                Array.from(files).forEach(f => formData.append('archivos[]', f));
                 fetch(`/ajax/capturas/${capturaId}/archivos`, {
                     method: 'POST',
                     headers: { 'X-CSRF-TOKEN': csrfToken },
@@ -2559,7 +2559,7 @@
                 for (const tr of pendientesArch) {
                     const file = $(tr).data('file');
                     const fd = new FormData();
-                    fd.append('archivos', file);
+                    fd.append('archivos[]', file);
                     const respArch = await fetch(`/ajax/capturas/${capturaId}/archivos`, {
                         method: 'POST',
                         headers: { 'X-CSRF-TOKEN': csrfToken },


### PR DESCRIPTION
## Summary
- Ensure capture file inputs use `archivos[]` for immediate and deferred uploads
- Accept single or multiple files in `ArchivoCapturaAjaxController` and validate each file

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aff9c3fad08333a844f29a10da6d9d