### PR TITLE
Manejar errores de red al subir archivos de captura

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -2030,7 +2030,7 @@
                     } else {
                         alert('Error al subir archivo');
                     }
-                });
+                }).catch(err => mostrarErrorCaptura('Error de red al subir archivo'));
                 return;
             }
             const tbody = $('#archivos-captura-table tbody');
@@ -2565,8 +2565,8 @@
                         headers: { 'X-CSRF-TOKEN': csrfToken },
                         body: fd,
                         credentials: 'same-origin'
-                    });
-                    if (!respArch.ok) {
+                    }).catch(err => mostrarErrorCaptura('Error de red al subir archivo'));
+                    if (!respArch?.ok) {
                         mostrarErrorCaptura('Error al subir el archivo');
                         return;
                     }


### PR DESCRIPTION
## Summary
- Muestra un error claro de red cuando la carga de archivos falla en el formulario de captura.
- Maneja también errores de red al subir archivos pendientes.

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68affab6a774833380a2724f8b79bd98