### PR TITLE
feat: show additional trip details

### DIFF
--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -17,6 +17,14 @@
             <dd class="col-sm-8">{{ $viaje['campania_descripcion'] ?? '' }}</dd>
             <dt class="col-sm-4">Responsable</dt>
             <dd class="col-sm-8">{{ ($viaje['pescador_nombres'] ?? '') . ' ' . ($viaje['pescador_apellidos'] ?? '') }}</dd>
+            <dt class="col-sm-4">Digitador</dt>
+            <dd class="col-sm-8">{{ ($viaje['digitador_nombres'] ?? '') . ' ' . ($viaje['digitador_apellidos'] ?? '') }}</dd>
+            <dt class="col-sm-4">Puerto Zarpe</dt>
+            <dd class="col-sm-8">{{ $viaje['puerto_zarpe_nombre'] ?? '' }}</dd>
+            <dt class="col-sm-4">Puerto Arribo</dt>
+            <dd class="col-sm-8">{{ $viaje['puerto_arribo_nombre'] ?? '' }}</dd>
+            <dt class="col-sm-4">Muelle</dt>
+            <dd class="col-sm-8">{{ $viaje['muelle_nombre'] ?? '' }}</dd>
             <dt class="col-sm-4">Observaciones</dt>
             <dd class="col-sm-8">{{ $viaje['observaciones'] ?? '' }}</dd>
         </dl>


### PR DESCRIPTION
## Summary
- display digitador name and ports of departure/arrival in trip detail view
- show muelle and other missing attributes using null-safe operators

## Testing
- `composer test` *(fails: require(/workspace/ISOSPAM/vendor/autoload.php) failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b02bf26b28833381929520ca075b96