### PR TITLE
Consultar respuestas de viaje solo si faltan

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -334,17 +334,22 @@ class ViajeController extends Controller
         $respCapturas = $this->apiService->get('/capturas-viaje', ['viaje_id' => $id]);
         $capturas = $respCapturas->successful() ? $respCapturas->json() : [];
 
-        if (! empty($viaje['campania_id'] ?? null)) {
+        if (
+            ! empty($viaje['campania_id'] ?? null)
+            && empty($viaje['respuestas_multifinalitaria'] ?? null)
+        ) {
             $respMulti = $this->apiService->get('/respuestas-multifinalitaria', [
                 'campania_id' => $viaje['campania_id'],
                 'tabla_relacionada' => 'viaje',
                 'relacion_id' => $viaje['id'] ?? $id,
             ]);
-            $viaje['respuestas_multifinalitaria'] = $respMulti->successful()
-                ? $respMulti->json()
-                : [];
-        } else {
-            $viaje['respuestas_multifinalitaria'] = [];
+
+            if ($respMulti->successful()) {
+                $respuestas = $respMulti->json();
+                if (! empty($respuestas)) {
+                    $viaje['respuestas_multifinalitaria'] = $respuestas;
+                }
+            }
         }
 
         return view('viajes.mostrar', [


### PR DESCRIPTION
## Summary
- Call `/respuestas-multifinalitaria` in `ViajeController@mostrar` only when data is missing
- Preserve existing multifinalitaria answers unless fetch succeeds with non-empty result

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b0388ed92c83339a9adce56e1a7540