### PR TITLE
Mostrar detalles de viaje con listas desplegables

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -120,6 +120,13 @@ class ViajeController extends Controller
         $respCapturas = $this->apiService->get('/capturas-viaje', ['viaje_id' => $id]);
         $capturas = $respCapturas->successful() ? $respCapturas->json() : [];
 
+        $campanias = $this->getCampanias();
+        $responsables = $this->getPersonasPorRol('RESPVJ');
+        $digitadores = $this->getPersonasPorRol('CTF');
+        $embarcaciones = $this->getEmbarcaciones();
+        $puertos = $this->getPuertos();
+        $muelles = $this->getMuelles();
+
         $respObservadores = $this->apiService->get('/observadores-viaje', ['viaje_id' => $id]);
         $observadores = $respObservadores->successful() ? $respObservadores->json() : [];
 
@@ -334,6 +341,13 @@ class ViajeController extends Controller
         $respCapturas = $this->apiService->get('/capturas-viaje', ['viaje_id' => $id]);
         $capturas = $respCapturas->successful() ? $respCapturas->json() : [];
 
+        $campanias = $this->getCampanias();
+        $responsables = $this->getPersonasPorRol('RESPVJ');
+        $digitadores = $this->getPersonasPorRol('CTF');
+        $embarcaciones = $this->getEmbarcaciones();
+        $puertos = $this->getPuertos();
+        $muelles = $this->getMuelles();
+
         if (
             ! empty($viaje['campania_id'] ?? null)
             && empty($viaje['respuestas_multifinalitaria'] ?? null)
@@ -356,6 +370,12 @@ class ViajeController extends Controller
             'viaje' => $viaje,
             'tripulantes' => $tripulantes,
             'capturas' => $capturas,
+            'campanias' => $campanias,
+            'responsables' => $responsables,
+            'digitadores' => $digitadores,
+            'embarcaciones' => $embarcaciones,
+            'puertos' => $puertos,
+            'muelles' => $muelles,
         ]);
     }
 

--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -9,22 +9,42 @@
         <div class="row">
             <div class="col-md-3 mb-3">
                 <label class="form-label">Campaña</label>
-                <input type="text" class="form-control" value="{{ $viaje['campania_descripcion'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($campanias as $c)
+                        <option value="{{ $c['id'] }}" @selected(($viaje['campania_id'] ?? '')==$c['id'])>{{ $c['descripcion'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 
         <div class="row">
             <div class="col-md-4 mb-3">
                 <label class="form-label">Responsable Viaje</label>
-                <input type="text" class="form-control" value="{{ $viaje['pescador_nombres'] ?? '' }} {{ $viaje['pescador_apellidos'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($responsables as $per)
+                        <option value="{{ $per['idpersona'] }}" @selected(($viaje['persona_idpersona'] ?? '')==$per['idpersona'])>{{ $per['nombres'] ?? '' }} {{ $per['apellidos'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
             <div class="col-md-4 mb-3">
                 <label class="form-label">Digitador</label>
-                <input type="text" class="form-control" value="{{ $viaje['digitador_nombres'] ?? '' }} {{ $viaje['digitador_apellidos'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($digitadores as $d)
+                        <option value="{{ $d['idpersona'] }}" @selected(($viaje['digitador_id'] ?? '')==$d['idpersona'])>{{ $d['nombres'] ?? '' }} {{ $d['apellidos'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
             <div class="col-md-4 mb-3">
                 <label class="form-label">Embarcación</label>
-                <input type="text" class="form-control" value="{{ $viaje['embarcacion_nombre'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($embarcaciones as $e)
+                        <option value="{{ $e['id'] }}" @selected(($viaje['embarcacion_id'] ?? '')==$e['id'])>{{ $e['nombre'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 
@@ -39,7 +59,12 @@
             </div>
             <div class="col-md-4 mb-3">
                 <label class="form-label">Puerto Zarpe</label>
-                <input type="text" class="form-control" value="{{ $viaje['puerto_zarpe_nombre'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($puertos as $p)
+                        <option value="{{ $p['id'] }}" @selected(($viaje['puerto_zarpe_id'] ?? '')==$p['id'])>{{ $p['nombre'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 
@@ -54,14 +79,24 @@
             </div>
             <div class="col-md-4 mb-3">
                 <label class="form-label">Puerto Arribo</label>
-                <input type="text" class="form-control" value="{{ $viaje['puerto_arribo_nombre'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($puertos as $p)
+                        <option value="{{ $p['id'] }}" @selected(($viaje['puerto_arribo_id'] ?? '')==$p['id'])>{{ $p['nombre'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 
         <div class="row">
             <div class="col-md-4 mb-3">
                 <label class="form-label">Muelle</label>
-                <input type="text" class="form-control" value="{{ $viaje['muelle_nombre'] ?? '' }}" readonly>
+                <select class="form-control" disabled>
+                    <option value="">Seleccione...</option>
+                    @foreach($muelles as $m)
+                        <option value="{{ $m['id'] }}" @selected(($viaje['muelle_id'] ?? '')==$m['id'])>{{ $m['nombre'] ?? '' }}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Cargar catálogos de campañas, responsables, digitadores, embarcaciones, puertos y muelles en la acción `mostrar`.
- Mostrar campos de campaña, responsable, digitador, embarcación, puertos y muelle mediante `<select>` deshabilitados para reflejar la selección.

## Testing
- `php -l app/Http/Controllers/ViajeController.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b03aafdee483338c8901f1ac98cb73