### PR TITLE
Add selection form to viaje details view

### DIFF
--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -231,9 +231,15 @@
                     @endforelse
                 </tbody>
             </table>
-        </div>
-    </div>
+</div>
+</div>
 </div>
 
+@if(!($viajeSeleccionado ?? false))
+    <form method="POST" action="{{ route('viajes.seleccionar', $viaje['id']) }}" class="d-inline">
+        @csrf
+        <button type="submit" class="btn btn-primary btn-sm">Seleccionar</button>
+    </form>
+@endif
 <a href="{{ route('viajes.pendientes') }}" class="btn btn-secondary">Volver</a>
 @endsection


### PR DESCRIPTION
## Summary
- allow selecting a viaje from its detail view via POST form
- hide selection form when the trip is already selected

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b03c2f2dfc83338dfb5376d73c206c