### PR TITLE
feat: add confirmation to pending trips selection

### DIFF
--- a/resources/views/viajes/pendientes.blade.php
+++ b/resources/views/viajes/pendientes.blade.php
@@ -4,6 +4,9 @@
 <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h3 class="card-title mb-0">Viajes pendientes</h3>
+        <div class="card-tools">
+            <a href="{{ route('viajes.index') }}" class="btn btn-primary btn-sm">Volver</a>
+        </div>
     </div>
     <div class="card-body">
         <div class="table-responsive">
@@ -34,7 +37,7 @@
                         <td>{{ ($v['pescador_nombres'] ?? '') . ' ' . ($v['pescador_apellidos'] ?? '') }}</td>
                         <td class="text-right">
                             <a href="{{ route('viajes.mostrar', $v['id']) }}" class="btn btn-xs btn-info">Mostrar</a>
-                            <form method="POST" action="{{ route('viajes.seleccionar', $v['id']) }}" class="d-inline">
+                            <form method="POST" action="{{ route('viajes.seleccionar', $v['id']) }}" class="seleccionar-form d-inline">
                                 @csrf
                                 <button type="submit" class="btn btn-xs btn-primary">Seleccionar</button>
                             </form>
@@ -49,17 +52,30 @@
 @endsection
 
 @section('scripts')
-    
-    
-@endsection
-
-@section('scripts')
-@if(session('success'))
+    <script>
+        document.querySelectorAll('.seleccionar-form').forEach(form => {
+            form.addEventListener('submit', function(e) {
+                e.preventDefault();
+                Swal.fire({
+                    title: '¿Seleccionar viaje?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: 'Sí, seleccionar',
+                    cancelButtonText: 'Cancelar'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit();
+                    }
+                });
+            });
+        });
+    </script>
+    @if(session('success'))
         <script>
             Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
         </script>
     @endif
-@if(session('error'))
+    @if(session('error'))
         <script>
             Swal.fire({icon: 'error', title: 'Error', text: @json(session('error'))});
         </script>


### PR DESCRIPTION
## Summary
- add 'Volver' link and selection form class on pending trips view
- intercept selection submit with confirmation dialog

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b03ec8c7b0833395f295efa369fd2b