### PR TITLE
feat: show observers and environmental data

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -348,6 +348,15 @@ class ViajeController extends Controller
         $puertos = $this->getPuertos();
         $muelles = $this->getMuelles();
 
+        $respObservadores = $this->apiService->get('/observadores-viaje', ['viaje_id' => $id]);
+        $observadores = $respObservadores->successful() ? $respObservadores->json() : [];
+
+        $respParametros = $this->apiService->get('/parametros-ambientales', ['viaje_id' => $id]);
+        $parametrosAmbientales = $respParametros->successful() ? $respParametros->json() : [];
+
+        $respEconomia = $this->apiService->get("/economia-insumo-viaje/{$id}");
+        $economiaInsumos = $respEconomia->successful() ? $respEconomia->json() : [];
+
         if (
             ! empty($viaje['campania_id'] ?? null)
             && empty($viaje['respuestas_multifinalitaria'] ?? null)
@@ -376,6 +385,9 @@ class ViajeController extends Controller
             'embarcaciones' => $embarcaciones,
             'puertos' => $puertos,
             'muelles' => $muelles,
+            'observadores' => $observadores,
+            'parametrosAmbientales' => $parametrosAmbientales,
+            'economiaInsumos' => $economiaInsumos,
         ]);
     }
 

--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -244,6 +244,108 @@
 </div>
 </div>
 
+<div class="card mb-3">
+    <div class="card-header">
+        <h3 class="card-title">Observadores</h3>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th>Tipo</th>
+                        <th>Persona</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($observadores ?? [] as $o)
+                        <tr>
+                            <td>{{ $o['tipo_observador_descripcion'] ?? '' }}</td>
+                            <td>{{ $o['persona_nombres'] ?? '' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="2" class="text-center">No hay observadores registrados.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-3">
+    <div class="card-header">
+        <h3 class="card-title">Parámetros Ambientales</h3>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th>Hora</th>
+                        <th>Sondeo PPT</th>
+                        <th>TSMP</th>
+                        <th>Estado Marea</th>
+                        <th>Condición Mar</th>
+                        <th>Oxígeno mg/l</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($parametrosAmbientales ?? [] as $p)
+                        <tr>
+                            <td>{{ $p['hora'] ?? '' }}</td>
+                            <td>{{ $p['sondeo_ppt'] ?? '' }}</td>
+                            <td>{{ $p['tsmp'] ?? '' }}</td>
+                            <td>{{ $p['estado_marea_descripcion'] ?? '' }}</td>
+                            <td>{{ $p['condicion_mar_descripcion'] ?? '' }}</td>
+                            <td>{{ $p['oxigeno_mg_l'] ?? '' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center">No hay parámetros registrados.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-3">
+    <div class="card-header">
+        <h3 class="card-title">Economía de Insumos</h3>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th>Tipo</th>
+                        <th>Unidad</th>
+                        <th>Cantidad</th>
+                        <th>Precio</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($economiaInsumos ?? [] as $e)
+                        <tr>
+                            <td>{{ $e['nombre_tipo'] ?? '' }}</td>
+                            <td>{{ $e['nombre_unidad'] ?? '' }}</td>
+                            <td>{{ $e['cantidad'] ?? '' }}</td>
+                            <td>{{ $e['precio'] ?? '' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="4" class="text-center">No hay economía de insumos registrada.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
 @endsection
 
 @section('scripts')


### PR DESCRIPTION
## Summary
- show observer details in trip view
- show environmental parameters and input economy data
- load observer and environmental data for trip display

## Testing
- `./vendor/bin/phpunit`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0b7b5fdc08333b9a9ff5e315f85fe