### PR TITLE
Display capture details in viaje view

### DIFF
--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -187,6 +187,7 @@
                         <th>Tipo Nº Individuos</th>
                         <th>Tipo Peso</th>
                         <th>Estado Producto</th>
+                        <th>Detalles</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -202,17 +203,286 @@
                             <td>{{ $c['tipo_numero_individuos'] ?? '' }}</td>
                             <td>{{ $c['tipo_peso'] ?? '' }}</td>
                             <td>{{ $c['estado_producto'] ?? '' }}</td>
+                            <td>
+                                <button type="button" class="btn btn-info btn-xs" data-toggle="modal"
+                                    data-target="#capturaModal{{ $c['id'] ?? $loop->index }}">Ver</button>
+                            </td>
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="10" class="text-center">No hay capturas registradas.</td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
+                            <td colspan="11" class="text-center">No hay capturas registradas.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+    </div>
+</div>
+
+@foreach($capturas ?? [] as $captura)
+<div class="modal fade" id="capturaModal{{ $captura['id'] ?? $loop->index }}" tabindex="-1" role="dialog"
+    aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Captura</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body" style="max-height: 70vh; overflow-y: auto;">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label>Nombre común</label>
+                            <p class="form-control-plaintext">{{ $captura['nombre_comun'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Especie</label>
+                            <p class="form-control-plaintext">{{ $captura['especie_nombre'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Tipo Nº Individuos</label>
+                            <p class="form-control-plaintext">{{ $captura['tipo_numero_individuos'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Nº Individuos</label>
+                            <p class="form-control-plaintext">{{ $captura['numero_individuos'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Tipo Peso</label>
+                            <p class="form-control-plaintext">{{ $captura['tipo_peso'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Peso de captura</label>
+                            <p class="form-control-plaintext">{{ $captura['peso_estimado'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Estado Producto</label>
+                            <p class="form-control-plaintext">{{ $captura['estado_producto'] ?? '' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Es Incidental</label>
+                            <p class="form-control-plaintext">{{ ($captura['es_incidental'] ?? false) ? 'Sí' : 'No' }}</p>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label>Es Descartada</label>
+                            <p class="form-control-plaintext">{{ ($captura['es_descartada'] ?? false) ? 'Sí' : 'No' }}</p>
+                        </div>
+                        @if(!empty($captura['respuestas_multifinalitaria']))
+                            @foreach($captura['respuestas_multifinalitaria'] as $r)
+                                <div class="col-md-4 mb-3">
+                                    <label>{{ $r['nombre_pregunta'] ?? '' }}</label>
+                                    <p class="form-control-plaintext">{{ $r['respuesta'] ?? '' }}</p>
+                                </div>
+                            @endforeach
+                        @endif
+                    </div>
+                    @if(!empty($captura['sitios_pesca']))
+                        @php $s = $captura['sitios_pesca'][0] ?? null; @endphp
+                        <div id="sitio-pesca-card" class="card mb-3">
+                            <div class="card-header border-0 bg-dark">
+                                <h5 class="card-title mb-0">Sitio de pesca</h5>
+                            </div>
+                            <div class="card-body">
+                                @if($s)
+                                    <div class="row">
+                                        <div class="col-md-4 mb-3">
+                                            <label>Nombre</label>
+                                            <p class="form-control-plaintext">{{ $s['nombre'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Latitud</label>
+                                            <p class="form-control-plaintext">{{ $s['latitud'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Longitud</label>
+                                            <p class="form-control-plaintext">{{ $s['longitud'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Profundidad</label>
+                                            <p class="form-control-plaintext">{{ $s['profundidad'] ?? '' }} {{ $s['unidad_profundidad_nombre'] ?? '' }}</p>
+                                        </div>
+                                    </div>
+                                @else
+                                    <p class="mb-0">No registrado.</p>
+                                @endif
+                            </div>
+                        </div>
+                    @endif
+                    @if(!empty($captura['artes_pesca']))
+                        @php $a = $captura['artes_pesca'][0] ?? null; @endphp
+                        <div id="arte-pesca-card" class="card mb-3">
+                            <div class="card-header border-0 bg-dark">
+                                <h5 class="card-title mb-0">Arte de pesca</h5>
+                            </div>
+                            <div class="card-body">
+                                @if($a)
+                                    <div class="row">
+                                        <div class="col-md-4 mb-3">
+                                            <label>Tipo de arte</label>
+                                            <p class="form-control-plaintext">{{ $a['tipo_arte_nombre'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Líneas madre</label>
+                                            <p class="form-control-plaintext">{{ $a['lineas_madre'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Anzuelos</label>
+                                            <p class="form-control-plaintext">{{ $a['anzuelos'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Tipo anzuelo</label>
+                                            <p class="form-control-plaintext">{{ $a['tipo_anzuelo_nombre'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Tamaño anzuelo (pulg)</label>
+                                            <p class="form-control-plaintext">{{ $a['tamanio_anzuelo_pulg'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Largo red (m)</label>
+                                            <p class="form-control-plaintext">{{ $a['largo_red_m'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Ancho red (m)</label>
+                                            <p class="form-control-plaintext">{{ $a['alto_red_m'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Material malla</label>
+                                            <p class="form-control-plaintext">{{ $a['material_malla_nombre'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Ojo malla (cm)</label>
+                                            <p class="form-control-plaintext">{{ $a['ojo_malla_cm'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Diámetro</label>
+                                            <p class="form-control-plaintext">{{ $a['diametro'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Carnada viva</label>
+                                            <p class="form-control-plaintext">{{ isset($a['carnadaviva']) ? ($a['carnadaviva'] ? 'Sí' : 'No') : '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Especie carnada</label>
+                                            <p class="form-control-plaintext">{{ $a['especiecarnada'] ?? '' }}</p>
+                                        </div>
+                                    </div>
+                                @else
+                                    <p class="mb-0">No registrado.</p>
+                                @endif
+                            </div>
+                        </div>
+                    @endif
+                    @if(!empty($captura['economia_ventas']))
+                        @php $ev = $captura['economia_ventas'][0] ?? null; @endphp
+                        <div id="economia-venta-card" class="card mb-3">
+                            <div class="card-header border-0 bg-dark">
+                                <h5 class="card-title mb-0">Dato económico</h5>
+                            </div>
+                            <div class="card-body">
+                                @if($ev)
+                                    <div class="row">
+                                        <div class="col-md-4 mb-3">
+                                            <label>Vendido a</label>
+                                            <p class="form-control-plaintext">{{ $ev['vendido_a'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Destino</label>
+                                            <p class="form-control-plaintext">{{ $ev['destino'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Precio</label>
+                                            <p class="form-control-plaintext">{{ $ev['precio'] ?? '' }}</p>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <label>Unidad de venta</label>
+                                            <p class="form-control-plaintext">{{ $ev['unidad_venta_nombre'] ?? '' }}</p>
+                                        </div>
+                                    </div>
+                                @else
+                                    <p class="mb-0">No registrado.</p>
+                                @endif
+                            </div>
+                        </div>
+                    @endif
+                    @if(!empty($captura['datos_biologicos']))
+                        <div id="dato-biologico-card" class="card mb-3">
+                            <div class="card-header border-0 bg-dark">
+                                <h5 class="card-title mb-0">Datos biológicos</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-compact mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>Longitud</th>
+                                                <th>Peso</th>
+                                                <th>Sexo</th>
+                                                <th>Ovada</th>
+                                                <th>Estado</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @forelse($captura['datos_biologicos'] as $d)
+                                                <tr>
+                                                    <td>{{ $d['longitud'] ?? '' }}</td>
+                                                    <td>{{ $d['peso'] ?? '' }}</td>
+                                                    <td>{{ $d['sexo'] ?? '' }}</td>
+                                                    <td>{{ ($d['ovada'] ?? false) ? 'Sí' : 'No' }}</td>
+                                                    <td>{{ $d['estado_desarrollo_gonadal_descripcion'] ?? '' }}</td>
+                                                </tr>
+                                            @empty
+                                                <tr>
+                                                    <td colspan="5" class="text-center">No hay datos registrados.</td>
+                                                </tr>
+                                            @endforelse
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                    @if(!empty($captura['archivos']))
+                        <div id="archivo-captura-card" class="card mb-3">
+                            <div class="card-header border-0 bg-dark">
+                                <h5 class="card-title mb-0">Archivos</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-compact mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>Nombre</th>
+                                                <th>Tamaño</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @forelse($captura['archivos'] as $a)
+                                                <tr>
+                                                    <td><a href="{{ $a['url'] ?? '#' }}" target="_blank">{{ $a['nombre_original'] ?? '' }}</a></td>
+                                                    <td>{{ $a['tamano'] ?? '' }}</td>
+                                                </tr>
+                                            @empty
+                                                <tr>
+                                                    <td colspan="2" class="text-center">No hay archivos.</td>
+                                                </tr>
+                                            @endforelse
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+            </div>
         </div>
     </div>
 </div>
+@endforeach
 
 <div class="card mb-3">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- add per-capture detail button and modal in viaje show view
- present capture attributes and related records in read-only sections

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b0bcbfa4fc833381384be5ae378bbc