### PR TITLE
Muestra alerta de error al finalizar viaje

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -299,6 +299,7 @@ class ViajeController extends Controller
         if ($response->failed()) {
             return redirect()
                 ->route('viajes.edit', ['viaje' => $id, 'por_finalizar' => 1])
+                ->with('error', 'Error al actualizar')
                 ->withErrors(['error' => 'Error al actualizar'])
                 ->withInput();
         }
@@ -312,6 +313,7 @@ class ViajeController extends Controller
 
         return redirect()
             ->route('viajes.edit', ['viaje' => $id, 'por_finalizar' => 1])
+            ->with('error', 'Error al finalizar')
             ->withErrors(['error' => 'Error al finalizar'])
             ->withInput();
     }


### PR DESCRIPTION
## Resumen
- Agrega mensaje flash de error en `updatePorFinalizar` para mostrar alerta SweetAlert cuando falle la finalización de un viaje.

## Pruebas
- `composer test` *(falla: require(/workspace/ISOSPAM/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68b145417b2883338bf2395514fd0817