### PR TITLE
Show feedback when finalizing a trip

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -1141,9 +1141,25 @@
                 cancelButtonText: 'Cancelar'
             }).then(result => {
                 if (result.isConfirmed) {
-                    const form = document.getElementById('viaje-form');
-                    form.action = this.getAttribute('formaction');
-                    form.submit();
+                    const btn = this;
+                    const form = $('#viaje-form');
+                    $.ajax({
+                        url: btn.getAttribute('formaction'),
+                        method: 'POST',
+                        data: form.serialize(),
+                        success: resp => {
+                            Swal.fire({ icon: 'success', title: 'Éxito', text: resp.message || 'Viaje finalizado' })
+                                .then(() => { if (resp.redirect) window.location.href = resp.redirect; });
+                        },
+                        error: xhr => {
+                            const json = xhr.responseJSON || {};
+                            let msg = json.message || 'Error al finalizar';
+                            if (json.errors) {
+                                msg = Object.values(json.errors).flat().join(' ');
+                            }
+                            Swal.fire({ icon: 'error', title: 'Error', text: msg });
+                        }
+                    });
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Return JSON with redirect and message for AJAX finalization requests
- Use AJAX in trip edit form to finalize and show SweetAlert feedback

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b148b42e3883339a3d5c8bdf8f9775