### PR TITLE
Proxy file downloads through API

### DIFF
--- a/app/Http/Controllers/ArchivoController.php
+++ b/app/Http/Controllers/ArchivoController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+
+class ArchivoController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function show(string $path)
+    {
+        $response = $this->apiService->getFile($path);
+
+        $headers = array_map(fn ($v) => $v[0], $response->headers());
+
+        return response($response->body(), $response->status())
+            ->withHeaders($headers);
+    }
+}
+

--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -49,6 +49,18 @@ class ApiService
         return $this->withToken()->get($url, $query);
     }
 
+    public function getFile(string $path)
+    {
+        $base = str_replace('/isospam', '', $this->baseUrl);
+        $request = Http::baseUrl($base);
+
+        if (Session::has('token')) {
+            $request = $request->withToken(Session::get('token'));
+        }
+
+        return $request->get("/archivos/{$path}");
+    }
+
     public function post(string $url, array $data = [])
     {
         return $this->withToken()->post($url, $data);

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ use App\Http\Controllers\EconomiaInsumoAjaxController;
 use App\Http\Controllers\EconomiaVentaAjaxController;
 use App\Http\Controllers\DatoBiologicoAjaxController;
 use App\Http\Controllers\ArchivoCapturaAjaxController;
+use App\Http\Controllers\ArchivoController;
 
 Route::get('/', function () {
     return view('home');
@@ -109,6 +110,8 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::get('ajax/capturas/{captura}/archivos', [ArchivoCapturaAjaxController::class, 'index']);
     Route::post('ajax/capturas/{captura}/archivos', [ArchivoCapturaAjaxController::class, 'store']);
     Route::delete('ajax/archivos/{archivo}', [ArchivoCapturaAjaxController::class, 'destroy']);
+
+    Route::get('archivos/{path}', [ArchivoController::class, 'show'])->where('path', '.*');
 
     Route::get('ajax/datos-biologicos', [DatoBiologicoAjaxController::class, 'index']);
     Route::get('ajax/datos-biologicos/{id}', [DatoBiologicoAjaxController::class, 'show']);


### PR DESCRIPTION
## Summary
- Add `ApiService::getFile` to fetch files without `/isospam` prefix
- Use `getFile` in `ArchivoController` for proxying downloads

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b1ce929a6c8333a3f7a9ebee027065