### PR TITLE
Add tabla multifinalitaria management for campaigns

### DIFF
--- a/app/Http/Controllers/TablaMultifinalitariaController.php
+++ b/app/Http/Controllers/TablaMultifinalitariaController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ApiService;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class TablaMultifinalitariaController extends Controller
+{
+    public function __construct(private ApiService $apiService)
+    {
+    }
+
+    public function index($campania)
+    {
+        $response = $this->apiService->get("/tabla-multifinalitaria/campania/{$campania}");
+        $campos = $response->successful() ? $response->json() : [];
+
+        return view('campanias.tabla-multifinalitaria', [
+            'campaniaId' => $campania,
+            'campos' => $campos,
+        ]);
+    }
+
+    public function store(Request $request, $campania)
+    {
+        $data = $this->validateData($request);
+        $data['campania_id'] = $campania;
+
+        $response = $this->apiService->post('/tabla-multifinalitaria', $data);
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.tabla-multifinalitaria.index', $campania)
+                ->with('success', 'Campo creado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al crear'])->withInput();
+    }
+
+    public function update(Request $request, $campania, $id)
+    {
+        $data = $this->validateData($request);
+
+        $response = $this->apiService->put("/tabla-multifinalitaria/{$id}", $data);
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.tabla-multifinalitaria.index', $campania)
+                ->with('success', 'Campo actualizado correctamente');
+        }
+
+        return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+    }
+
+    public function destroy($campania, $id)
+    {
+        $response = $this->apiService->delete("/tabla-multifinalitaria/{$id}");
+
+        if ($response->successful()) {
+            return redirect()->route('campanias.tabla-multifinalitaria.index', $campania)
+                ->with('success', 'Campo eliminado');
+        }
+
+        return back()->withErrors(['error' => 'Error al eliminar']);
+    }
+
+    protected function validateData(Request $request): array
+    {
+        $data = $request->validate([
+            'tabla_relacionada' => ['required', 'string'],
+            'campo' => ['required', 'string'],
+            'tipo_pregunta' => ['required', Rule::in(['COMBO','INTEGER','DATE','TIME','INPUT'])],
+            'opciones' => ['nullable', 'string'],
+        ]);
+
+        if (($data['tipo_pregunta'] ?? '') === 'COMBO') {
+            $opciones = json_decode($data['opciones'] ?? '[]', true) ?: [];
+            $data['opciones'] = json_encode(array_map(fn($o) => ['key' => $o, 'value' => $o], $opciones));
+        } else {
+            unset($data['opciones']);
+        }
+
+        return $data;
+    }
+}
+

--- a/resources/views/campanias/form.blade.php
+++ b/resources/views/campanias/form.blade.php
@@ -29,6 +29,9 @@
     @endif
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('campanias.index') }}" class="btn btn-secondary">Cancelar</a>
+    @if(isset($campania))
+        <a href="{{ route('campanias.tabla-multifinalitaria.index', $campania['id']) }}" class="btn btn-info">Tabla Multifinalitaria</a>
+    @endif
 </form>
 @endsection
 

--- a/resources/views/campanias/tabla-multifinalitaria.blade.php
+++ b/resources/views/campanias/tabla-multifinalitaria.blade.php
@@ -1,0 +1,178 @@
+@extends('layouts.dashboard')
+
+@section('spinner')
+    <x-spinner />
+@endsection
+
+@section('content')
+<h3>Tabla Multifinalitaria</h3>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Tabla relacionada</th>
+            <th>Campo</th>
+            <th>Tipo</th>
+            <th>Opciones</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($campos as $campo)
+            <tr>
+                <td>{{ $campo['tabla_relacionada'] ?? '' }}</td>
+                <td>{{ $campo['campo'] ?? '' }}</td>
+                <td>{{ $campo['tipo_pregunta'] ?? '' }}</td>
+                <td>
+                    @if(isset($campo['opciones']) && is_array($campo['opciones']))
+                        {{ implode(', ', array_map(fn($o) => $o['value'] ?? $o['key'] ?? '', $campo['opciones'])) }}
+                    @endif
+                </td>
+                <td>
+                    <button type="button" class="btn btn-sm btn-primary btn-edit"
+                        data-id="{{ $campo['id'] }}"
+                        data-tabla="{{ $campo['tabla_relacionada'] }}"
+                        data-campo="{{ $campo['campo'] }}"
+                        data-tipo="{{ $campo['tipo_pregunta'] }}"
+                        data-opciones='{{ json_encode(array_map(fn($o) => $o['value'] ?? $o['key'] ?? '', $campo['opciones'] ?? [])) }}'>Editar</button>
+                    <form method="POST" action="{{ route('campanias.tabla-multifinalitaria.destroy', [$campaniaId, $campo['id']]) }}" style="display:inline">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+                    </form>
+                </td>
+            </tr>
+        @empty
+            <tr><td colspan="5" class="text-center">Sin registros</td></tr>
+        @endforelse
+    </tbody>
+</table>
+
+<h4 id="form-title">Nuevo Campo</h4>
+<form method="POST" id="campo-form" action="{{ route('campanias.tabla-multifinalitaria.store', $campaniaId) }}">
+    @csrf
+    <div id="method-field"></div>
+    <div class="mb-3">
+        <label class="form-label">Tabla Relacionada</label>
+        <input type="text" name="tabla_relacionada" class="form-control" id="tabla_relacionada">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Campo</label>
+        <input type="text" name="campo" class="form-control" id="campo">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Tipo de Pregunta</label>
+        <select name="tipo_pregunta" class="form-control" id="tipo_pregunta">
+            <option value="">Seleccione</option>
+            <option value="COMBO">COMBO</option>
+            <option value="INTEGER">INTEGER</option>
+            <option value="DATE">DATE</option>
+            <option value="TIME">TIME</option>
+            <option value="INPUT">INPUT</option>
+        </select>
+    </div>
+    <div id="opciones-section" class="mb-3 d-none">
+        <label class="form-label">Opciones</label>
+        <div id="opciones-container"></div>
+        <button type="button" class="btn btn-sm btn-secondary" id="add-opcion">Agregar opción</button>
+        <input type="hidden" name="opciones" id="opciones-input">
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <button type="button" class="btn btn-secondary" id="cancel-edit" style="display:none">Cancelar</button>
+    <a href="{{ route('campanias.index') }}" class="btn btn-secondary">Volver</a>
+</form>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('campo-form');
+    const methodField = document.getElementById('method-field');
+    const tipo = document.getElementById('tipo_pregunta');
+    const opcionesSection = document.getElementById('opciones-section');
+    const addBtn = document.getElementById('add-opcion');
+    const container = document.getElementById('opciones-container');
+    const opcionesInput = document.getElementById('opciones-input');
+    const cancelBtn = document.getElementById('cancel-edit');
+    const formTitle = document.getElementById('form-title');
+    const baseUpdateUrl = "{{ url('campanias/'.$campaniaId.'/tabla-multifinalitaria') }}";
+
+    function refreshOpciones() {
+        const values = Array.from(container.querySelectorAll('.opcion')).map(i => i.value).filter(v => v.trim() !== '');
+        opcionesInput.value = JSON.stringify(values);
+    }
+
+    tipo.addEventListener('change', function () {
+        if (this.value === 'COMBO') {
+            opcionesSection.classList.remove('d-none');
+        } else {
+            opcionesSection.classList.add('d-none');
+            container.innerHTML = '';
+            opcionesInput.value = '';
+        }
+    });
+
+    addBtn.addEventListener('click', function () {
+        const div = document.createElement('div');
+        div.classList.add('input-group','mb-2');
+        div.innerHTML = '<input type="text" class="form-control opcion"><div class="input-group-append"><button class="btn btn-danger remove-opcion" type="button"><i class="fas fa-times"></i></button></div>';
+        container.appendChild(div);
+    });
+
+    container.addEventListener('click', function (e) {
+        if (e.target.closest('.remove-opcion')) {
+            e.target.closest('.input-group').remove();
+            refreshOpciones();
+        }
+    });
+
+    form.addEventListener('submit', function () {
+        refreshOpciones();
+    });
+
+    document.querySelectorAll('.btn-edit').forEach(btn => {
+        btn.addEventListener('click', function () {
+            const data = this.dataset;
+            form.action = `${baseUpdateUrl}/${data.id}`;
+            methodField.innerHTML = '<input type="hidden" name="_method" value="PUT">';
+            document.getElementById('tabla_relacionada').value = data.tabla;
+            document.getElementById('campo').value = data.campo;
+            document.getElementById('tipo_pregunta').value = data.tipo;
+            const opciones = JSON.parse(data.opciones || '[]');
+            container.innerHTML = '';
+            if (data.tipo === 'COMBO') {
+                opcionesSection.classList.remove('d-none');
+                opciones.forEach(o => {
+                    const div = document.createElement('div');
+                    div.classList.add('input-group','mb-2');
+                    div.innerHTML = `<input type="text" class="form-control opcion" value="${o}"><div class="input-group-append"><button class="btn btn-danger remove-opcion" type="button"><i class="fas fa-times"></i></button></div>`;
+                    container.appendChild(div);
+                });
+            } else {
+                opcionesSection.classList.add('d-none');
+            }
+            opcionesInput.value = JSON.stringify(opciones);
+            cancelBtn.style.display = 'inline-block';
+            formTitle.textContent = 'Editar Campo';
+        });
+    });
+
+    cancelBtn.addEventListener('click', function () {
+        form.action = "{{ route('campanias.tabla-multifinalitaria.store', $campaniaId) }}";
+        methodField.innerHTML = '';
+        form.reset();
+        container.innerHTML = '';
+        opcionesSection.classList.add('d-none');
+        opcionesInput.value = '';
+        cancelBtn.style.display = 'none';
+        formTitle.textContent = 'Nuevo Campo';
+    });
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\EmbarcacionController;
 use App\Http\Controllers\CampaniaController;
+use App\Http\Controllers\TablaMultifinalitariaController;
 use App\Http\Controllers\PuertoController;
 use App\Http\Controllers\MuelleController;
 use App\Http\Controllers\TipoArteController;
@@ -70,6 +71,12 @@ Route::get('/logout', [LoginController::class, 'logout'])->middleware('ensure.lo
 Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('embarcaciones', EmbarcacionController::class)->except(['show']);
     Route::resource('campanias', CampaniaController::class)->except(['show']);
+    Route::prefix('campanias/{campania}')->group(function () {
+        Route::get('tabla-multifinalitaria', [TablaMultifinalitariaController::class, 'index'])->name('campanias.tabla-multifinalitaria.index');
+        Route::post('tabla-multifinalitaria', [TablaMultifinalitariaController::class, 'store'])->name('campanias.tabla-multifinalitaria.store');
+        Route::put('tabla-multifinalitaria/{id}', [TablaMultifinalitariaController::class, 'update'])->name('campanias.tabla-multifinalitaria.update');
+        Route::delete('tabla-multifinalitaria/{id}', [TablaMultifinalitariaController::class, 'destroy'])->name('campanias.tabla-multifinalitaria.destroy');
+    });
     Route::get('ajax/campos-dinamicos', [CampaniaController::class, 'camposDinamicos']);
     Route::resource('puertos', PuertoController::class)->except(['show']);
     Route::resource('muelles', MuelleController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add nested routes and controller to manage tabla multifinalitaria records for campaigns
- create UI to list and edit fields with dynamic COMBO options
- link campaigns form to new tabla multifinalitaria screen

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e6697ed08333829de246abeb119d