### PR TITLE
Use value/key for dynamic combo options

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -217,8 +217,8 @@
                         <option value="">Seleccione...</option>
                         @foreach($opciones as $opt)
                         @php
-                        $value = is_array($opt) ? ($opt['valor'] ?? '') : (string) $opt;
-                        $text = is_array($opt) ? ($opt['texto'] ?? '') : (string) $opt;
+                        $value = is_array($opt) ? ($opt['value'] ?? '') : (string) $opt;
+                        $text = is_array($opt) ? ($opt['key'] ?? $opt['value'] ?? '') : (string) $opt;
                         @endphp
                         <option value="{{ $value }}" @selected(($resp['respuesta'] ?? '' )==$value)>{{ $text }}</option>
                         @endforeach
@@ -1312,8 +1312,8 @@
                         try { opciones = JSON.parse(campo.opciones || '[]'); } catch (e) { }
                         control = '<select class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + index + '][respuesta]"><option value="">Seleccione...</option>';
                         opciones.forEach(function (opt) {
-                            var value = (typeof opt === 'object') ? (opt.valor || '') : String(opt);
-                            var text = (typeof opt === 'object') ? (opt.texto || '') : String(opt);
+                            var value = (typeof opt === 'object') ? (opt.value || '') : String(opt);
+                            var text = (typeof opt === 'object') ? (opt.key || opt.value || '') : String(opt);
                             control += '<option value="' + value + '">' + text + '</option>';
                         });
                         control += '</select>';
@@ -1364,8 +1364,8 @@
                         try { opciones = JSON.parse(campo.opciones || '[]'); } catch (e) { }
                         control = '<select class="form-control" ' + requerido + ' name="respuestas_multifinalitaria[' + key + '][respuesta]"><option value="">Seleccione...</option>';
                         opciones.forEach(function (opt) {
-                            var value = (typeof opt === 'object') ? (opt.valor || '') : String(opt);
-                            var text = (typeof opt === 'object') ? (opt.texto || '') : String(opt);
+                            var value = (typeof opt === 'object') ? (opt.value || '') : String(opt);
+                            var text = (typeof opt === 'object') ? (opt.key || opt.value || '') : String(opt);
                             var selected = (resp.respuesta || '') == value ? ' selected' : '';
                             control += '<option value="' + value + '"' + selected + '>' + text + '</option>';
                         });

--- a/resources/views/viajes/mostrar.blade.php
+++ b/resources/views/viajes/mostrar.blade.php
@@ -197,8 +197,8 @@
                         <option value="">Seleccione...</option>
                         @foreach($opciones as $opt)
                         @php
-                        $value = is_array($opt) ? ($opt['valor'] ?? '') : (string) $opt;
-                        $text = is_array($opt) ? ($opt['texto'] ?? '') : (string) $opt;
+                        $value = is_array($opt) ? ($opt['value'] ?? '') : (string) $opt;
+                        $text = is_array($opt) ? ($opt['key'] ?? $opt['value'] ?? '') : (string) $opt;
                         @endphp
                         <option value="{{ $value }}" @selected(($resp['respuesta'] ?? '' )==$value)>{{ $text }}</option>
                         @endforeach
@@ -813,8 +813,8 @@
                         try { opciones = JSON.parse(campo.opciones || '[]'); } catch (e) { }
                         control = '<select class="form-control" name="respuestas_multifinalitaria[' + key + '][respuesta]" disabled><option value="">Seleccione...</option>';
                         opciones.forEach(function (opt) {
-                            var value = (typeof opt === 'object') ? (opt.valor || '') : String(opt);
-                            var text = (typeof opt === 'object') ? (opt.texto || '') : String(opt);
+                            var value = (typeof opt === 'object') ? (opt.value || '') : String(opt);
+                            var text = (typeof opt === 'object') ? (opt.key || opt.value || '') : String(opt);
                             var selected = (resp.respuesta || '') == value ? ' selected' : '';
                             control += '<option value="' + value + '"' + selected + '>' + text + '</option>';
                         });


### PR DESCRIPTION
## Summary
- Read dynamic combo options using `value` and `key`
- Adjust dynamic field JS to reference new option keys

## Testing
- `composer test`
- `node -e "const campos=[{tipo_pregunta:'COMBO', opciones:JSON.stringify([{value:'1',key:'Uno'},{value:'2',key:'Dos'},{value:'3'}])}];function renderOptions(campo){ let res=[]; let opciones=JSON.parse(campo.opciones||'[]'); opciones.forEach(opt=>{ const value = typeof opt === 'object' ? (opt.value || '') : String(opt); const text = typeof opt === 'object' ? (opt.key || opt.value || '') : String(opt); res.push({value,text}); }); return res;} console.log(renderOptions(campos[0]));"`
- `node -e "const payload={campania_id:1,respuestas_multifinalitaria:[{tabla_multifinalitaria_id:5,respuesta:'A'}]}; console.log(JSON.stringify(payload));"`


------
https://chatgpt.com/codex/tasks/task_e_68b1f63eae54833389accda3315b658c