### PR TITLE
Ensure campaign id is sent on tabla multifinalitaria updates

### DIFF
--- a/app/Http/Controllers/TablaMultifinalitariaController.php
+++ b/app/Http/Controllers/TablaMultifinalitariaController.php
@@ -48,6 +48,7 @@ class TablaMultifinalitariaController extends Controller
     public function update(Request $request, $campania, $id)
     {
         $data = $this->validateData($request);
+        $data['campania_id'] = $campania;
 
         $response = $this->apiService->put("/tabla-multifinalitaria/{$id}", $data);
 


### PR DESCRIPTION
## Summary
- Ensure `campania_id` is included when updating TablaMultifinalitaria entries so the API receives the associated campaign

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b1e3589ac48333ad60019943f87531