### PR TITLE
Enable read-only view for Viajes using shared form

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -399,7 +399,19 @@ class ViajeController extends Controller
             }
         }
 
-        return view('viajes.mostrar', [
+        $respuestasMulti = $viaje['respuestas_multifinalitaria'] ?? [];
+        $camposDinamicos = collect($respuestasMulti)
+            ->map(fn($r) => [
+                'id' => $r['tabla_multifinalitaria_id'] ?? null,
+                'nombre_pregunta' => $r['nombre_pregunta'] ?? '',
+                'tipo_pregunta' => $r['tipo_pregunta'] ?? 'INPUT',
+                'opciones' => is_array($r['opciones'] ?? null)
+                    ? json_encode($r['opciones'])
+                    : ($r['opciones'] ?? '[]'),
+                'requerido' => $r['requerido'] ?? false,
+            ])->all();
+
+        return view('viajes.form', [
             'viaje' => $viaje,
             'tripulantes' => $tripulantes,
             'capturas' => $capturas,
@@ -412,6 +424,8 @@ class ViajeController extends Controller
             'observadores' => $observadores,
             'parametrosAmbientales' => $parametrosAmbientales,
             'economiaInsumos' => $economiaInsumos,
+            'camposDinamicos' => $camposDinamicos,
+            'soloLectura' => true,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Reuse viaje form for show action by building dynamic fields and returning it in read-only mode
- Add read-only handling in viaje form: disable inputs, hide submit buttons and skip interactive scripts when `$soloLectura`

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b127cc4e18833393b216d52ccf6edb