### PR TITLE
Limit related table options to captura and viaje

### DIFF
--- a/app/Http/Controllers/TablaMultifinalitariaController.php
+++ b/app/Http/Controllers/TablaMultifinalitariaController.php
@@ -75,7 +75,7 @@ class TablaMultifinalitariaController extends Controller
     protected function validateData(Request $request): array
     {
         $data = $request->validate([
-            'tabla_relacionada' => ['required', 'string'],
+            'tabla_relacionada' => ['required', Rule::in(['captura','viaje'])],
             'nombre_pregunta' => ['required', 'string'],
             'tipo_pregunta' => ['required', Rule::in(['COMBO','INTEGER','DATE','TIME','INPUT'])],
             'opciones' => ['nullable', 'string'],

--- a/resources/views/campanias/tabla-multifinalitaria.blade.php
+++ b/resources/views/campanias/tabla-multifinalitaria.blade.php
@@ -60,7 +60,11 @@
     <div id="method-field"></div>
     <div class="mb-3">
         <label class="form-label">Tabla Relacionada</label>
-        <input type="text" name="tabla_relacionada" class="form-control" id="tabla_relacionada">
+        <select name="tabla_relacionada" class="form-control" id="tabla_relacionada">
+            <option value="">Seleccione</option>
+            <option value="captura">captura</option>
+            <option value="viaje">viaje</option>
+        </select>
     </div>
     <div class="mb-3">
         <label class="form-label">Campo</label>


### PR DESCRIPTION
## Summary
- Restrict `Tabla Relacionada` field to a combo with `captura` and `viaje` choices
- Validate `tabla_relacionada` server side using an allowed list

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b20f4e1d6c8333b338b8dbcc9955d2