### PR TITLE
Add fishing organization API and integrate tripulante selection

### DIFF
--- a/app/Http/Controllers/ApiProxyController.php
+++ b/app/Http/Controllers/ApiProxyController.php
@@ -112,5 +112,11 @@ class ApiProxyController extends Controller
         $resp = $this->apiService->get("/personas/{$id}");
         return response()->json($resp->json(), $resp->status());
     }
+
+    public function getOrganizacionesPesquera(): JsonResponse
+    {
+        $resp = $this->apiService->get('/organizacion-pesquera');
+        return response()->json($resp->json(), $resp->status());
+    }
 }
 

--- a/app/Http/Controllers/TripulanteViajeAjaxController.php
+++ b/app/Http/Controllers/TripulanteViajeAjaxController.php
@@ -33,6 +33,7 @@ class TripulanteViajeAjaxController extends Controller
             'viaje_id' => ['required', 'integer'],
             'tipo_tripulante_id' => ['required', 'integer'],
             'persona_idpersona' => ['required', 'integer'],
+            'organizacion_pesquera_id' => ['required', 'integer'],
         ]);
 
         $resp = $this->apiService->post('/tripulantes-viaje', $data);
@@ -46,6 +47,7 @@ class TripulanteViajeAjaxController extends Controller
             'viaje_id' => ['required', 'integer'],
             'tipo_tripulante_id' => ['required', 'integer'],
             'persona_idpersona' => ['required', 'integer'],
+            'organizacion_pesquera_id' => ['required', 'integer'],
         ]);
 
         $resp = $this->apiService->put("/tripulantes-viaje/{$id}", $data);

--- a/app/Http/Controllers/TripulanteViajeController.php
+++ b/app/Http/Controllers/TripulanteViajeController.php
@@ -39,6 +39,7 @@ class TripulanteViajeController extends Controller
             'viaje_id' => ['required', 'integer'],
             'tipo_tripulante_id' => ['required', 'integer'],
             'persona_idpersona' => ['required', 'integer'],
+            'organizacion_pesquera_id' => ['required', 'integer'],
         ]);
 
         $resp = $this->apiService->post('/tripulantes-viaje', $data);
@@ -71,6 +72,7 @@ class TripulanteViajeController extends Controller
             'viaje_id' => ['required', 'integer'],
             'tipo_tripulante_id' => ['required', 'integer'],
             'persona_idpersona' => ['required', 'integer'],
+            'organizacion_pesquera_id' => ['required', 'integer'],
         ]);
 
         $resp = $this->apiService->put("/tripulantes-viaje/{$id}", $data);

--- a/resources/views/tripulantes-viaje/form.blade.php
+++ b/resources/views/tripulantes-viaje/form.blade.php
@@ -25,6 +25,12 @@
             <option value="">Seleccione...</option>
         </select>
     </div>
+    <div class="mb-3">
+        <label class="form-label">Organización Pesquera</label>
+        <select name="organizacion_pesquera_id" id="organizacion_pesquera_id" class="form-control" required>
+            <option value="">Seleccione...</option>
+        </select>
+    </div>
     @if($errors->any())
         <div class="alert alert-danger">{{ $errors->first() }}</div>
     @endif
@@ -38,6 +44,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     const tipoSelect = document.getElementById('tipo_tripulante_id');
     const personaSelect = $('#persona_idpersona');
+    const orgSelect = document.getElementById('organizacion_pesquera_id');
     const selectedTipo = @json(old('tipo_tripulante_id', $tripulante['tipo_tripulante_id'] ?? ''));
     fetch('{{ route('api.tipos-tripulante') }}')
         .then(r => r.json())
@@ -45,6 +52,15 @@ document.addEventListener('DOMContentLoaded', function() {
             data.forEach(t => {
                 const opt = new Option(t.descripcion, t.id, false, String(t.id) === String(selectedTipo));
                 tipoSelect.appendChild(opt);
+            });
+        });
+    const selectedOrg = @json(old('organizacion_pesquera_id', $tripulante['organizacion_pesquera_id'] ?? ''));
+    fetch('{{ route('api.organizacion-pesquera') }}')
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(o => {
+                const opt = new Option(o.nombre ?? o.id, o.id, false, String(o.id) === String(selectedOrg));
+                orgSelect.appendChild(opt);
             });
         });
     personaSelect.select2({

--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -355,6 +355,7 @@
                     <tr>
                         <th>Tipo</th>
                         <th>Persona</th>
+                        <th>Organización</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -363,6 +364,7 @@
                     <tr>
                         <td>{{ $t['tipo_tripulante_nombre'] ?? '' }}</td>
                         <td>{{ $t['tripulante_nombres'] ?? '' }}</td>
+                        <td>{{ $t['organizacion_pesquera_nombre'] ?? '' }}</td>
                         <td class="text-right">
                             <button class="btn btn-xs btn-secondary editar-tripulante"
                                 data-id="{{ $t['id'] }}">Editar</button>
@@ -402,6 +404,13 @@
                     <div class="form-group">
                         <label>Persona</label>
                         <select class="form-control" id="persona_tripulante_idpersona">
+                            <option value="">Seleccione...</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label>Organización Pesquera</label>
+                        <select class="form-control" id="organizacion_pesquera_id" required>
                             <option value="">Seleccione...</option>
                         </select>
                     </div>
@@ -1470,6 +1479,20 @@
                 .catch(err => console.error('Error al cargar tipos de tripulante:', err));
         }
 
+        function cargarOrganizacionesPesqueras(selected = '') {
+            const select = $('#organizacion_pesquera_id');
+            select.empty().append('<option value="">Seleccione...</option>');
+            fetch("{{ route('api.organizacion-pesquera') }}")
+                .then(response => response.json())
+                .then(data => {
+                    data.forEach(o => {
+                        const opt = new Option(o.nombre ?? o.id, o.id, false, String(o.id) === String(selected));
+                        select.append(opt);
+                    });
+                })
+                .catch(err => console.error('Error al cargar organizaciones pesqueras:', err));
+        }
+
         function cargarUnidadesProfundidad(selected = '') {
             const select = $('#sitio-unidad-profundidad');
             select.empty().append('<option value="">Seleccione...</option>');
@@ -1580,6 +1603,7 @@
                         const row = `<tr>
                                 <td>${t.tipo_tripulante_nombre ?? ''}</td>
                                 <td>${t.tripulante_nombres ?? ''}</td>
+                                <td>${t.organizacion_pesquera_nombre ?? ''}</td>
                                 <td class=\"text-right\">
                                     <button class=\"btn btn-xs btn-secondary editar-tripulante\" data-id=\"${t.id}\">Editar</button>
                                     <button class=\"btn btn-xs btn-danger eliminar-tripulante\" data-id=\"${t.id}\">Eliminar</button>
@@ -2334,6 +2358,7 @@
         function abrirTripulanteModal(data = {}) {
             $('#tripulante-id').val(data.id || '');
             cargarTiposTripulante(data.tipo_tripulante_id || '');
+            cargarOrganizacionesPesqueras(data.organizacion_pesquera_id || '');
             const personaSelect = $('#persona_tripulante_idpersona');
             if (data.persona_idpersona) {
                 const opt = new Option(data.tripulante_nombres || '', data.persona_idpersona, true, true);
@@ -2674,7 +2699,8 @@
             const payload = {
                 viaje_id: viajeId,
                 tipo_tripulante_id: $('#tipo_tripulante_id').val(),
-                persona_idpersona: $('#persona_tripulante_idpersona').val()
+                persona_idpersona: $('#persona_tripulante_idpersona').val(),
+                organizacion_pesquera_id: $('#organizacion_pesquera_id').val()
             };
             const url = id ? `${ajaxBase}/tripulantes-viaje/${id}` : `${ajaxBase}/tripulantes-viaje`;
             const method = id ? 'PUT' : 'POST';

--- a/routes/web.php
+++ b/routes/web.php
@@ -250,3 +250,4 @@ Route::get('/api/estados-desarrollo-gonadal', [ApiProxyController::class, 'getEs
 Route::get('/api/sitios', [ApiProxyController::class, 'getSitios'])->name('api.sitios');
 Route::get('/api/personas', [ApiProxyController::class, 'getPersonas'])->name('api.personas');
 Route::get('/api/personas/{id}', [ApiProxyController::class, 'getPersona'])->name('api.personas.show');
+Route::get('/api/organizacion-pesquera', [ApiProxyController::class, 'getOrganizacionesPesquera'])->name('api.organizacion-pesquera');


### PR DESCRIPTION
## Summary
- expose `/api/organizacion-pesquera` proxy endpoint
- require and send `organizacion_pesquera_id` for tripulante records
- load and display fishing organization in tripulante forms and travel modal

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b5312e2eac8333a672656ce09d70d7