### PR TITLE
refactor: use fetch in captura modals

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -2445,20 +2445,24 @@
 
         function editarCaptura(id) {
             $('.spinner-overlay').removeClass('d-none');
-            $.ajax({
-                url: `${ajaxBase}/capturas/${id}`,
-                success: data => abrirModal(data),
-                error: () => $('.spinner-overlay').addClass('d-none')
-            });
+            fetch(`${ajaxBase}/capturas/${id}`)
+                .then(response => {
+                    if (!response.ok) throw new Error('Network response was not ok');
+                    return response.json();
+                })
+                .then(data => abrirModal(data))
+                .catch(() => $('.spinner-overlay').addClass('d-none'));
         }
 
         function verCaptura(id) {
             $('.spinner-overlay').removeClass('d-none');
-            $.ajax({
-                url: `${ajaxBase}/capturas/${id}`,
-                success: data => abrirModal(data, true),
-                error: () => $('.spinner-overlay').addClass('d-none')
-            });
+            fetch(`${ajaxBase}/capturas/${id}`)
+                .then(response => {
+                    if (!response.ok) throw new Error('Network response was not ok');
+                    return response.json();
+                })
+                .then(data => abrirModal(data, true))
+                .catch(() => $('.spinner-overlay').addClass('d-none'));
         }
 
         function editarObservador(id) {


### PR DESCRIPTION
## Summary
- Use `fetch` instead of `$.ajax` for editar/ver captura
- Ensure spinner hides only after modal opens

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test`
- `php artisan serve` *(manually verify spinner at http://localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68b547b9f52483339525eac8759ab3be