### PR TITLE
Ocultar botones "Agregar" en modo lectura

### DIFF
--- a/resources/views/viajes/form.blade.php
+++ b/resources/views/viajes/form.blade.php
@@ -335,7 +335,9 @@
                 </tbody>
             </table>
         </div>
+        @empty($soloLectura)
         <button id="agregar-captura" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+        @endempty
     </div>
 </div>
 
@@ -386,7 +388,9 @@
                 </tbody>
             </table>
         </div>
+        @empty($soloLectura)
         <button id="agregar-tripulante" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+        @endempty
     </div>
 </div>
 
@@ -480,7 +484,9 @@
                 </tbody>
             </table>
         </div>
+        @empty($soloLectura)
         <button id="agregar-observador" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+        @endempty
     </div>
 </div>
 
@@ -809,7 +815,9 @@
                                         <tbody></tbody>
                                     </table>
                                 </div>
+                                @empty($soloLectura)
                                 <button id="agregar-dato-biologico" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+                                @endempty
                             </div>
                         </div>
                         <div id="archivo-captura-card" class="card mb-3 collapsed-card">
@@ -834,7 +842,9 @@
                                         <tbody></tbody>
                                     </table>
                                 </div>
+                                @empty($soloLectura)
                                 <button id="agregar-archivo-captura" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+                                @endempty
                             </div>
                         </div>
                     </div>
@@ -977,7 +987,9 @@
                 </tbody>
             </table>
         </div>
+        @empty($soloLectura)
         <button id="agregar-parametro" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+        @endempty
     </div>
 </div>
 
@@ -1078,7 +1090,9 @@
                 </tbody>
             </table>
         </div>
+        @empty($soloLectura)
         <button id="agregar-economia-insumo" type="button" class="btn btn-primary btn-xs mt-2">Agregar</button>
+        @endempty
     </div>
 </div>
 


### PR DESCRIPTION
## Resumen
- Oculta los botones de **Agregar** en capturas, tripulantes, observadores, parámetros ambientales y economía de insumo cuando el formulario se muestra en modo de solo lectura.
- Evita que en los modales de captura se muestren opciones para añadir datos biológicos o archivos si la vista está en modo lectura.

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b536f4ba908333bedc22fc7f9f0c89