### PR TITLE
feat: add usuarios management

### DIFF
--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class UsuarioController extends Controller
+{
+    private $conn;
+
+    public function __construct()
+    {
+        $this->conn = DB::connection('reportes');
+    }
+
+    public function index()
+    {
+        $usuarios = $this->conn->table('usuario')
+            ->join('persona', 'persona.idpersona', '=', 'usuario.idpersona')
+            ->select('usuario.idusuario', 'usuario.usuario', 'usuario.activo', 'persona.nombres', 'persona.apellidos')
+            ->get();
+
+        return view('usuarios.index', [
+            'usuarios' => $usuarios,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('usuarios.form');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'identificacion' => ['required', 'string'],
+            'nombres' => ['required', 'string'],
+            'apellidos' => ['required', 'string'],
+            'direccion' => ['nullable', 'string'],
+            'celular' => ['nullable', 'string'],
+            'email' => ['nullable', 'email'],
+            'usuario' => ['required', 'string'],
+            'clave' => ['required', 'string'],
+            'activo' => ['nullable', 'boolean'],
+        ]);
+
+        try {
+            DB::connection('reportes')->transaction(function () use ($data) {
+                $personaId = DB::connection('reportes')->table('persona')->insertGetId([
+                    'identificacion' => $data['identificacion'],
+                    'nombres' => $data['nombres'],
+                    'apellidos' => $data['apellidos'],
+                    'direccion' => $data['direccion'] ?? null,
+                    'celular' => $data['celular'] ?? null,
+                    'email' => $data['email'] ?? null,
+                ]);
+
+                DB::connection('reportes')->table('usuario')->insert([
+                    'idpersona' => $personaId,
+                    'usuario' => $data['usuario'],
+                    'clave' => $data['clave'],
+                    'activo' => $data['activo'] ?? false,
+                ]);
+            });
+
+            return redirect()->route('usuarios.index')->with('success', 'Usuario creado correctamente');
+        } catch (\Throwable $e) {
+            return back()->withErrors(['error' => 'Error al crear'])->withInput();
+        }
+    }
+
+    public function edit(int $id)
+    {
+        $usuario = $this->conn->table('usuario')->where('idusuario', $id)->first();
+        if (! $usuario) {
+            abort(404);
+        }
+        $persona = $this->conn->table('persona')->where('idpersona', $usuario->idpersona)->first();
+
+        return view('usuarios.form', [
+            'usuario' => $usuario,
+            'persona' => $persona,
+        ]);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $usuario = $this->conn->table('usuario')->where('idusuario', $id)->first();
+        if (! $usuario) {
+            abort(404);
+        }
+
+        $data = $request->validate([
+            'identificacion' => ['required', 'string'],
+            'nombres' => ['required', 'string'],
+            'apellidos' => ['required', 'string'],
+            'direccion' => ['nullable', 'string'],
+            'celular' => ['nullable', 'string'],
+            'email' => ['nullable', 'email'],
+            'usuario' => ['required', 'string'],
+            'clave' => ['required', 'string'],
+            'activo' => ['nullable', 'boolean'],
+        ]);
+
+        try {
+            DB::connection('reportes')->transaction(function () use ($data, $usuario, $id) {
+                DB::connection('reportes')->table('persona')->where('idpersona', $usuario->idpersona)->update([
+                    'identificacion' => $data['identificacion'],
+                    'nombres' => $data['nombres'],
+                    'apellidos' => $data['apellidos'],
+                    'direccion' => $data['direccion'] ?? null,
+                    'celular' => $data['celular'] ?? null,
+                    'email' => $data['email'] ?? null,
+                ]);
+
+                DB::connection('reportes')->table('usuario')->where('idusuario', $id)->update([
+                    'usuario' => $data['usuario'],
+                    'clave' => $data['clave'],
+                    'activo' => $data['activo'] ?? false,
+                ]);
+            });
+
+            return redirect()->route('usuarios.index')->with('success', 'Usuario actualizado correctamente');
+        } catch (\Throwable $e) {
+            return back()->withErrors(['error' => 'Error al actualizar'])->withInput();
+        }
+    }
+
+    public function destroy(int $id)
+    {
+        try {
+            DB::connection('reportes')->transaction(function () use ($id) {
+                $usuario = DB::connection('reportes')->table('usuario')->where('idusuario', $id)->first();
+                if ($usuario) {
+                    DB::connection('reportes')->table('usuario')->where('idusuario', $id)->delete();
+                    DB::connection('reportes')->table('persona')->where('idpersona', $usuario->idpersona)->delete();
+                }
+            });
+
+            return redirect()->route('usuarios.index')->with('success', 'Usuario eliminado');
+        } catch (\Throwable $e) {
+            return back()->withErrors(['error' => 'Error al eliminar']);
+        }
+    }
+}

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -293,6 +293,12 @@
                                         <p>Roles por Persona</p>
                                     </a>
                                 </li>
+                                <li class="nav-item">
+                                    <a href="{{ route('usuarios.index') }}" class="nav-link">
+                                        <i class="far fa-circle nav-icon"></i>
+                                        <p>Usuarios</p>
+                                    </a>
+                                </li>
                             </ul>
                         </li>
 

--- a/resources/views/usuarios/form.blade.php
+++ b/resources/views/usuarios/form.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.dashboard')
+
+@section('spinner')
+    <x-spinner />
+@endsection
+
+@section('content')
+<h3>{{ isset($usuario) ? 'Editar' : 'Nuevo' }} Usuario</h3>
+<form method="POST" action="{{ isset($usuario) ? route('usuarios.update', $usuario->idusuario) : route('usuarios.store') }}">
+    @csrf
+    @if(isset($usuario))
+        @method('PUT')
+    @endif
+    <div class="mb-3">
+        <label class="form-label">Identificación</label>
+        <input type="text" name="identificacion" class="form-control" value="{{ old('identificacion', $persona->identificacion ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Nombres</label>
+        <input type="text" name="nombres" class="form-control" value="{{ old('nombres', $persona->nombres ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Apellidos</label>
+        <input type="text" name="apellidos" class="form-control" value="{{ old('apellidos', $persona->apellidos ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Dirección</label>
+        <input type="text" name="direccion" class="form-control" value="{{ old('direccion', $persona->direccion ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Celular</label>
+        <input type="text" name="celular" class="form-control" value="{{ old('celular', $persona->celular ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ old('email', $persona->email ?? '') }}">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Usuario</label>
+        <input type="text" name="usuario" class="form-control" value="{{ old('usuario', $usuario->usuario ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Clave</label>
+        <input type="text" name="clave" class="form-control" value="{{ old('clave', $usuario->clave ?? '') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Activo</label>
+        <select name="activo" class="form-control">
+            <option value="1" @selected(old('activo', $usuario->activo ?? 1)==1)>Sí</option>
+            <option value="0" @selected(old('activo', $usuario->activo ?? 1)==0)>No</option>
+        </select>
+    </div>
+    @if($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('usuarios.index') }}" class="btn btn-secondary">Cancelar</a>
+</form>
+@endsection

--- a/resources/views/usuarios/index.blade.php
+++ b/resources/views/usuarios/index.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.dashboard')
+
+@section('spinner')
+    <x-spinner />
+@endsection
+
+@section('content')
+<div class="d-flex justify-content-between mb-3">
+    <h3>Usuarios</h3>
+    <a href="{{ route('usuarios.create') }}" class="btn btn-primary">Nuevo</a>
+</div>
+
+<table class="table table-dark table-striped table-compact">
+    <thead>
+        <tr>
+            <th>Usuario</th>
+            <th>Nombres</th>
+            <th>Apellidos</th>
+            <th>Activo</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($usuarios as $u)
+        <tr>
+            <td>{{ $u->usuario }}</td>
+            <td>{{ $u->nombres }}</td>
+            <td>{{ $u->apellidos }}</td>
+            <td>{{ $u->activo ? 'Sí' : 'No' }}</td>
+            <td class="text-right">
+                <a href="{{ route('usuarios.edit', $u->idusuario) }}" class="btn btn-xs btn-secondary">Editar</a>
+                <form action="{{ route('usuarios.destroy', $u->idusuario) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-xs btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection
+
+@section('scripts')
+@if(session('success'))
+    <script>
+        Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});
+    </script>
+@endif
+@if($errors->any())
+    <script>
+        Swal.fire({icon: 'error', title: 'Error', html: `<ul>@foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach</ul>`});
+    </script>
+@endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\MenuController;
 use App\Http\Controllers\RolController;
 use App\Http\Controllers\RolMenuController;
 use App\Http\Controllers\RolPersonaController;
+use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\ViajeController;
 use App\Http\Controllers\CapturaController;
 use App\Http\Controllers\CapturaAjaxController;
@@ -175,6 +176,7 @@ Route::middleware('ensure.logged.in')->group(function () {
 
     Route::delete('rolpersona/{idpersona}/{idrol}', [RolPersonaController::class, 'destroy'])->name('rolpersona.destroy');
     Route::resource('rolpersona', RolPersonaController::class)->only(['index', 'create', 'store']);
+    Route::resource('usuarios', UsuarioController::class)->except(['show']);
 });
 
 


### PR DESCRIPTION
## Summary
- add UsuarioController for managing personas and usuarios via reportes DB
- add views and routes for usuarios CRUD
- link usuarios in dashboard navigation

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b579cfc0688333a97e1ab686b0993e