### PR TITLE
Replace usuario ID with persona ID and enforce uniqueness

### DIFF
--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -18,7 +18,7 @@ class UsuarioController extends Controller
     {
         $usuarios = $this->conn->table('usuario')
             ->join('persona', 'persona.idpersona', '=', 'usuario.idpersona')
-            ->select('usuario.idusuario', 'usuario.usuario', 'usuario.activo', 'persona.nombres', 'persona.apellidos')
+            ->select('usuario.idpersona', 'usuario.usuario', 'usuario.activo', 'persona.nombres', 'persona.apellidos')
             ->get();
 
         return view('usuarios.index', [
@@ -72,7 +72,7 @@ class UsuarioController extends Controller
 
     public function edit(int $id)
     {
-        $usuario = $this->conn->table('usuario')->where('idusuario', $id)->first();
+        $usuario = $this->conn->table('usuario')->where('idpersona', $id)->first();
         if (! $usuario) {
             abort(404);
         }
@@ -86,7 +86,7 @@ class UsuarioController extends Controller
 
     public function update(Request $request, int $id)
     {
-        $usuario = $this->conn->table('usuario')->where('idusuario', $id)->first();
+        $usuario = $this->conn->table('usuario')->where('idpersona', $id)->first();
         if (! $usuario) {
             abort(404);
         }
@@ -114,7 +114,7 @@ class UsuarioController extends Controller
                     'email' => $data['email'] ?? null,
                 ]);
 
-                DB::connection('reportes')->table('usuario')->where('idusuario', $id)->update([
+                DB::connection('reportes')->table('usuario')->where('idpersona', $id)->update([
                     'usuario' => $data['usuario'],
                     'clave' => $data['clave'],
                     'activo' => $data['activo'] ?? false,
@@ -131,10 +131,10 @@ class UsuarioController extends Controller
     {
         try {
             DB::connection('reportes')->transaction(function () use ($id) {
-                $usuario = DB::connection('reportes')->table('usuario')->where('idusuario', $id)->first();
+                $usuario = DB::connection('reportes')->table('usuario')->where('idpersona', $id)->first();
                 if ($usuario) {
-                    DB::connection('reportes')->table('usuario')->where('idusuario', $id)->delete();
-                    DB::connection('reportes')->table('persona')->where('idpersona', $usuario->idpersona)->delete();
+                    DB::connection('reportes')->table('usuario')->where('idpersona', $id)->delete();
+                    DB::connection('reportes')->table('persona')->where('idpersona', $id)->delete();
                 }
             });
 

--- a/database/migrations/2025_09_01_155445_add_unique_to_usuario_idpersona.php
+++ b/database/migrations/2025_09_01_155445_add_unique_to_usuario_idpersona.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::connection('reportes')->table('usuario', function (Blueprint $table) {
+            $table->unique('idpersona');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::connection('reportes')->table('usuario', function (Blueprint $table) {
+            $table->dropUnique(['idpersona']);
+        });
+    }
+};

--- a/resources/views/usuarios/form.blade.php
+++ b/resources/views/usuarios/form.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
 <h3>{{ isset($usuario) ? 'Editar' : 'Nuevo' }} Usuario</h3>
-<form method="POST" action="{{ isset($usuario) ? route('usuarios.update', $usuario->idusuario) : route('usuarios.store') }}">
+<form method="POST" action="{{ isset($usuario) ? route('usuarios.update', $usuario->idpersona) : route('usuarios.store') }}">
     @csrf
     @if(isset($usuario))
         @method('PUT')

--- a/resources/views/usuarios/index.blade.php
+++ b/resources/views/usuarios/index.blade.php
@@ -28,8 +28,8 @@
             <td>{{ $u->apellidos }}</td>
             <td>{{ $u->activo ? 'Sí' : 'No' }}</td>
             <td class="text-right">
-                <a href="{{ route('usuarios.edit', $u->idusuario) }}" class="btn btn-xs btn-secondary">Editar</a>
-                <form action="{{ route('usuarios.destroy', $u->idusuario) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                <a href="{{ route('usuarios.edit', $u->idpersona) }}" class="btn btn-xs btn-secondary">Editar</a>
+                <form action="{{ route('usuarios.destroy', $u->idpersona) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
                     @csrf
                     @method('DELETE')
                     <button type="submit" class="btn btn-xs btn-danger">Eliminar</button>


### PR DESCRIPTION
## Summary
- use `idpersona` instead of `idusuario` throughout UsuarioController and views
- add database migration to enforce unique `usuario.idpersona`

## Testing
- `php artisan test`
- `php artisan migrate` *(fails: The SQLite database configured for this application does not exist: C:/xampp/htdocs/ISOSPAM/database/database.sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c18a4f4c8333a23bf3e08328d943