### PR TITLE
Add persona search for user selection

### DIFF
--- a/app/Http/Controllers/PersonaController.php
+++ b/app/Http/Controllers/PersonaController.php
@@ -115,4 +115,17 @@ class PersonaController extends Controller
 
         return response()->json($data);
     }
+
+    public function buscar(Request $request)
+    {
+        $filtro = $request->query('filtro');
+
+        $resp = $this->apiService->get('/personas/buscar', [
+            'filtro' => $filtro,
+        ]);
+
+        $data = $resp->successful() ? $resp->json() : [];
+
+        return response()->json($data);
+    }
 }

--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -34,35 +34,19 @@ class UsuarioController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'identificacion' => ['required', 'string'],
-            'nombres' => ['required', 'string'],
-            'apellidos' => ['required', 'string'],
-            'direccion' => ['nullable', 'string'],
-            'celular' => ['nullable', 'string'],
-            'email' => ['nullable', 'email'],
+            'idpersona' => ['required', 'integer'],
             'usuario' => ['required', 'string'],
             'clave' => ['required', 'string'],
             'activo' => ['nullable', 'boolean'],
         ]);
 
         try {
-            DB::connection('reportes')->transaction(function () use ($data) {
-                $personaId = DB::connection('reportes')->table('persona')->insertGetId([
-                    'identificacion' => $data['identificacion'],
-                    'nombres' => $data['nombres'],
-                    'apellidos' => $data['apellidos'],
-                    'direccion' => $data['direccion'] ?? null,
-                    'celular' => $data['celular'] ?? null,
-                    'email' => $data['email'] ?? null,
-                ]);
-
-                DB::connection('reportes')->table('usuario')->insert([
-                    'idpersona' => $personaId,
-                    'usuario' => $data['usuario'],
-                    'clave' => $data['clave'],
-                    'activo' => $data['activo'] ?? false,
-                ]);
-            });
+            DB::connection('reportes')->table('usuario')->insert([
+                'idpersona' => $data['idpersona'],
+                'usuario' => $data['usuario'],
+                'clave' => $data['clave'],
+                'activo' => $data['activo'] ?? false,
+            ]);
 
             return redirect()->route('usuarios.index')->with('success', 'Usuario creado correctamente');
         } catch (\Throwable $e) {
@@ -76,11 +60,9 @@ class UsuarioController extends Controller
         if (! $usuario) {
             abort(404);
         }
-        $persona = $this->conn->table('persona')->where('idpersona', $usuario->idpersona)->first();
 
         return view('usuarios.form', [
             'usuario' => $usuario,
-            'persona' => $persona,
         ]);
     }
 
@@ -92,34 +74,19 @@ class UsuarioController extends Controller
         }
 
         $data = $request->validate([
-            'identificacion' => ['required', 'string'],
-            'nombres' => ['required', 'string'],
-            'apellidos' => ['required', 'string'],
-            'direccion' => ['nullable', 'string'],
-            'celular' => ['nullable', 'string'],
-            'email' => ['nullable', 'email'],
+            'idpersona' => ['required', 'integer'],
             'usuario' => ['required', 'string'],
             'clave' => ['required', 'string'],
             'activo' => ['nullable', 'boolean'],
         ]);
 
         try {
-            DB::connection('reportes')->transaction(function () use ($data, $usuario, $id) {
-                DB::connection('reportes')->table('persona')->where('idpersona', $usuario->idpersona)->update([
-                    'identificacion' => $data['identificacion'],
-                    'nombres' => $data['nombres'],
-                    'apellidos' => $data['apellidos'],
-                    'direccion' => $data['direccion'] ?? null,
-                    'celular' => $data['celular'] ?? null,
-                    'email' => $data['email'] ?? null,
-                ]);
-
-                DB::connection('reportes')->table('usuario')->where('idpersona', $id)->update([
-                    'usuario' => $data['usuario'],
-                    'clave' => $data['clave'],
-                    'activo' => $data['activo'] ?? false,
-                ]);
-            });
+            DB::connection('reportes')->table('usuario')->where('idpersona', $id)->update([
+                'idpersona' => $data['idpersona'],
+                'usuario' => $data['usuario'],
+                'clave' => $data['clave'],
+                'activo' => $data['activo'] ?? false,
+            ]);
 
             return redirect()->route('usuarios.index')->with('success', 'Usuario actualizado correctamente');
         } catch (\Throwable $e) {

--- a/resources/views/usuarios/form.blade.php
+++ b/resources/views/usuarios/form.blade.php
@@ -8,32 +8,14 @@
 <h3>{{ isset($usuario) ? 'Editar' : 'Nuevo' }} Usuario</h3>
 <form method="POST" action="{{ isset($usuario) ? route('usuarios.update', $usuario->idpersona) : route('usuarios.store') }}">
     @csrf
-    @if(isset($usuario))
+    @isset($usuario)
         @method('PUT')
-    @endif
+    @endisset
     <div class="mb-3">
-        <label class="form-label">Identificación</label>
-        <input type="text" name="identificacion" class="form-control" value="{{ old('identificacion', $persona->identificacion ?? '') }}" required>
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Nombres</label>
-        <input type="text" name="nombres" class="form-control" value="{{ old('nombres', $persona->nombres ?? '') }}" required>
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Apellidos</label>
-        <input type="text" name="apellidos" class="form-control" value="{{ old('apellidos', $persona->apellidos ?? '') }}" required>
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Dirección</label>
-        <input type="text" name="direccion" class="form-control" value="{{ old('direccion', $persona->direccion ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Celular</label>
-        <input type="text" name="celular" class="form-control" value="{{ old('celular', $persona->celular ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Email</label>
-        <input type="email" name="email" class="form-control" value="{{ old('email', $persona->email ?? '') }}">
+        <label class="form-label">Persona</label>
+        <select id="persona_id" name="idpersona" class="form-control">
+            <option value="">Seleccione...</option>
+        </select>
     </div>
     <div class="mb-3">
         <label class="form-label">Usuario</label>
@@ -56,4 +38,48 @@
     <button type="submit" class="btn btn-primary">Guardar</button>
     <a href="{{ route('usuarios.index') }}" class="btn btn-secondary">Cancelar</a>
 </form>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const personaSelect = $('#persona_id');
+    const usuarioInput = $('input[name="usuario"]');
+    personaSelect.select2({
+        width: '100%',
+        placeholder: 'Seleccione...',
+        allowClear: true,
+        ajax: {
+            url: "{{ route('ajax.personas.buscar') }}",
+            dataType: 'json',
+            delay: 250,
+            data: params => ({ filtro: params.term }),
+            processResults: data => ({
+                results: $.map(data, p => ({
+                    id: p.idpersona,
+                    text: `${p.cedula ?? ''} - ${`${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim()}`.trim(),
+                    cedula: p.cedula
+                }))
+            }),
+            cache: true
+        }
+    });
+    personaSelect.on('select2:select', e => {
+        usuarioInput.val(e.params.data.cedula || '').prop('readonly', true);
+    }).on('select2:clear', () => {
+        usuarioInput.val('').prop('readonly', false);
+    });
+    const selectedPersona = @json(old('idpersona', $usuario->idpersona ?? ''));
+    if (selectedPersona) {
+        fetch(`{{ route('api.personas') }}/${selectedPersona}`)
+            .then(r => r.json())
+            .then(p => {
+                const text = `${p.cedula ?? ''} - ${`${p.nombres ?? ''} ${p.apellidos ?? ''}`.trim()}`.trim();
+                const opt = new Option(text, p.idpersona, true, true);
+                personaSelect.append(opt).trigger('change');
+                usuarioInput.val(p.cedula || '').prop('readonly', true);
+            });
+    }
+});
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,6 +99,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('estadodesarrollogonadal', EstadoDesarrolloGonadalController::class)->except(['show']);
     Route::resource('personas', PersonaController::class)->except(['show']);
     Route::get('ajax/personas', [PersonaController::class, 'buscarPorRol'])->name('ajax.personas');
+    Route::get('ajax/personas/buscar', [PersonaController::class, 'buscar'])->name('ajax.personas.buscar');
     Route::resource('familias', FamiliaController::class)->except(['show']);
     Route::resource('especies', EspecieController::class)->except(['show']);
     Route::resource('organizacionpesquera', OrganizacionPesqueraController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- expose ajax route to search personas and return API results
- allow UsuarioController to link existing personas and skip persona creation
- integrate Select2 persona lookup in user form
- autofill username with selected persona's cedula and keep field readonly

## Testing
- `composer test` (fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)


------
https://chatgpt.com/codex/tasks/task_e_68b5cb8e56bc83338d44a62a9f5d3fef