### PR TITLE
Implement recursive menu management

### DIFF
--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Menu extends Model
+{
+    protected $connection = 'reportes';
+    protected $table = 'menu';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'url',
+        'opcion',
+        'icono',
+        'idmenupadre',
+        'activo',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'idmenupadre');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'idmenupadre')->with('children');
+    }
+}
+

--- a/public/css/menus.css
+++ b/public/css/menus.css
@@ -1,0 +1,7 @@
+.menu-tree ul {
+    list-style: none;
+    padding-left: 1rem;
+}
+.menu-tree li {
+    margin: 0.25rem 0;
+}

--- a/public/js/menus.js
+++ b/public/js/menus.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.menu-toggle').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const target = document.querySelector(this.dataset.target);
+            if (target) {
+                target.classList.toggle('d-none');
+                this.textContent = target.classList.contains('d-none') ? '+' : '-';
+            }
+        });
+    });
+});

--- a/resources/views/menus/form.blade.php
+++ b/resources/views/menus/form.blade.php
@@ -4,50 +4,37 @@
     <x-spinner />
 @endsection
 
-
 @section('content')
 <h3>{{ isset($menu) ? 'Editar' : 'Nuevo' }} Menú</h3>
-<form method="POST" action="{{ isset($menu) ? route('menus.update', $menu['id']) : route('menus.store') }}">
+<form method="POST" action="{{ isset($menu) ? route('menus.update', $menu) : route('menus.store') }}">
     @csrf
     @if(isset($menu))
         @method('PUT')
     @endif
     <div class="mb-3">
         <label class="form-label">Opción</label>
-        <input type="text" name="opcion" class="form-control" value="{{ old('opcion', $menu['opcion'] ?? '') }}" required>
+        <input type="text" name="opcion" class="form-control" value="{{ old('opcion', $menu->opcion ?? '') }}" required>
     </div>
     <div class="mb-3">
         <label class="form-label">URL</label>
-        <input type="text" name="url" class="form-control" value="{{ old('url', $menu['url'] ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Nivel</label>
-        <input type="text" name="nivel" class="form-control" value="{{ old('nivel', $menu['nivel'] ?? '') }}">
+        <input type="text" name="url" class="form-control" value="{{ old('url', $menu->url ?? '') }}">
     </div>
     <div class="mb-3">
         <label class="form-label">Icono</label>
-        <input type="text" name="icono" class="form-control" value="{{ old('icono', $menu['icono'] ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">URL 2</label>
-        <input type="text" name="url2" class="form-control" value="{{ old('url2', $menu['url2'] ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Icono 2</label>
-        <input type="text" name="icono2" class="form-control" value="{{ old('icono2', $menu['icono2'] ?? '') }}">
+        <input type="text" name="icono" class="form-control" value="{{ old('icono', $menu->icono ?? '') }}">
     </div>
     <div class="mb-3">
         <label class="form-label">Menú Padre</label>
         <select name="idmenupadre" class="form-control">
             <option value="">Seleccione...</option>
             @foreach($menus as $m)
-                <option value="{{ $m['id'] }}" @selected(old('idmenupadre', $menu['idmenupadre'] ?? '') == $m['id'])>{{ $m['opcion'] ?? $m['id'] }}</option>
+                <option value="{{ $m->id }}" @selected(old('idmenupadre', $menu->idmenupadre ?? '') == $m->id)>{{ $m->opcion }}</option>
             @endforeach
         </select>
     </div>
     <div class="mb-3 form-check">
         <input type="hidden" name="activo" value="0">
-        <input type="checkbox" name="activo" value="1" class="form-check-input" id="activo" {{ old('activo', $menu['activo'] ?? true) ? 'checked' : '' }}>
+        <input type="checkbox" name="activo" value="1" class="form-check-input" id="activo" {{ old('activo', $menu->activo ?? true) ? 'checked' : '' }}>
         <label class="form-check-label" for="activo">Activo</label>
     </div>
     @if($errors->any())

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -5,44 +5,19 @@
 @endsection
 
 @section('content')
+<link rel="stylesheet" href="{{ asset('css/menus.css') }}">
 <div class="d-flex justify-content-between mb-3">
     <h3>Menús</h3>
     <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
 </div>
 
-
-<table class="table table-dark table-striped table-compact">
-    <thead>
-        <tr>
-            <th>Opción</th>
-            <th>Nivel</th>
-            <th>Padre</th>
-            <th>Activo</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach($menus as $menu)
-        <tr>
-            <td>{{ $menu['opcion'] ?? '' }}</td>
-            <td>{{ $menu['nivel'] ?? '' }}</td>
-            <td>{{ $menu['idmenupadre'] ?? '' }}</td>
-            <td>{{ isset($menu['activo']) && $menu['activo'] ? 'Sí' : 'No' }}</td>
-            <td class="text-right">
-                <a href="{{ route('menus.edit', $menu['id']) }}" class="btn btn-xs btn-secondary">Editar</a>
-                <form action="{{ route('menus.destroy', $menu['id']) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-xs btn-danger">Eliminar</button>
-                </form>
-            </td>
-        </tr>
-    @endforeach
-    </tbody>
-</table>
+<ul class="menu-tree list-unstyled">
+    @include('menus.tree', ['menus' => $menus])
+</ul>
 @endsection
 
 @section('scripts')
+<script src="{{ asset('js/menus.js') }}"></script>
 @if(session('success'))
     <script>
         Swal.fire({icon: 'success', title: 'Éxito', text: @json(session('success'))});

--- a/resources/views/menus/tree.blade.php
+++ b/resources/views/menus/tree.blade.php
@@ -1,0 +1,30 @@
+@foreach($menus as $menu)
+    <li>
+        <div class="d-flex align-items-center mb-1">
+            @if($menu->children->isNotEmpty())
+                <button class="btn btn-sm btn-link p-0 me-1 menu-toggle" data-target="#children-{{ $menu->id }}">-</button>
+            @else
+                <span class="me-3"></span>
+            @endif
+            <span class="flex-grow-1 {{ $menu->activo ? '' : 'text-muted' }}">{{ $menu->opcion }}</span>
+            <div class="btn-group btn-group-sm">
+                <a href="{{ route('menus.edit', $menu) }}" class="btn btn-secondary">Editar</a>
+                <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">Eliminar</button>
+                </form>
+                <form action="{{ route('menus.toggle', $menu) }}" method="POST" class="d-inline">
+                    @csrf
+                    @method('PATCH')
+                    <button type="submit" class="btn btn-{{ $menu->activo ? 'warning' : 'success' }}">{{ $menu->activo ? 'Desactivar' : 'Activar' }}</button>
+                </form>
+            </div>
+        </div>
+        @if($menu->children->isNotEmpty())
+            <ul id="children-{{ $menu->id }}" class="ms-4">
+                @include('menus.tree', ['menus' => $menu->children])
+            </ul>
+        @endif
+    </li>
+@endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -168,6 +168,7 @@ Route::middleware('ensure.logged.in')->group(function () {
     Route::post('ajax/economia-ventas', [EconomiaVentaAjaxController::class, 'store'])->name('ajax.economia-ventas.store');
     Route::put('ajax/economia-ventas/{id}', [EconomiaVentaAjaxController::class, 'update'])->name('ajax.economia-ventas.update');
 
+    Route::patch('menus/{menu}/toggle', [MenuController::class, 'toggle'])->name('menus.toggle');
     Route::resource('menus', MenuController::class)->except(['show']);
     Route::resource('roles', RolController::class)->except(['show']);
     Route::get('rolmenu/{idrol}/{idmenu}/edit', [RolMenuController::class, 'edit'])->name('rolmenu.edit');


### PR DESCRIPTION
## Summary
- Create Menu Eloquent model with recursive parent/child relations
- Rewrite MenuController to manage menus in local DB and prevent cyclic hierarchies
- Replace menu views with expandable tree, add toggle route, JS and styles

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b8521ec48333a8afcd5ab67702c3