### PR TITLE
Use reportes connection for menu parent validation

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Menu;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class MenuController extends Controller
 {
@@ -26,7 +27,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', 'exists:menu,id'],
+            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');
@@ -50,7 +51,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', 'exists:menu,id'],
+            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');


### PR DESCRIPTION
## Summary
- Validate `idmenupadre` against the `menu` table in the `reportes` connection

## Testing
- `php artisan test`
- `php artisan migrate --database=reportes` *(fails: SQLSTATE[08006] [7] connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f66e30f88333b82f18ec13ce5e92