### PR TITLE
Use reportes connection in menu validation

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Menu;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class MenuController extends Controller
 {
@@ -27,7 +26,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');
@@ -51,7 +50,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');


### PR DESCRIPTION
## Summary
- reference reportes connection in MenuController `idmenupadre` validation

## Testing
- `php artisan test`
- `php artisan migrate --database=reportes` *(fails: connection to server at "localhost" port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f840819483339aac42cda53ccdf1