### PR TITLE
Use reportes connection in menu validation and confirm menu deletes

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Menu;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class MenuController extends Controller
 {
@@ -27,7 +26,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');
@@ -51,7 +50,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');

--- a/public/js/menus.js
+++ b/public/js/menus.js
@@ -8,4 +8,25 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     });
+
+    document.querySelectorAll('.delete-menu-btn').forEach(function (btn) {
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            const form = this.closest('form');
+            Swal.fire({
+                title: '¿Eliminar?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí, eliminar',
+                cancelButtonText: 'Cancelar'
+            }).then(result => {
+                if (result.isConfirmed) {
+                    document.querySelector('.spinner-overlay').classList.remove('d-none');
+                    form.submit();
+                } else {
+                    document.querySelector('.spinner-overlay').classList.add('d-none');
+                }
+            });
+        });
+    });
 });

--- a/resources/views/menus/tree.blade.php
+++ b/resources/views/menus/tree.blade.php
@@ -9,10 +9,10 @@
             <span class="flex-grow-1 {{ $menu->activo ? '' : 'text-muted' }}">{{ $menu->opcion }}</span>
             <div class="btn-group btn-group-sm">
                 <a href="{{ route('menus.edit', $menu) }}" class="btn btn-secondary">Editar</a>
-                <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline delete-menu-form">
                     @csrf
                     @method('DELETE')
-                    <button type="submit" class="btn btn-danger">Eliminar</button>
+                    <button type="submit" class="btn btn-danger delete-menu-btn">Eliminar</button>
                 </form>
                 <form action="{{ route('menus.toggle', $menu) }}" method="POST" class="d-inline">
                     @csrf


### PR DESCRIPTION
## Summary
- reference reportes connection in MenuController `idmenupadre` validation
- prompt for SweetAlert confirmation before menu deletion and reset spinner on cancel

## Testing
- `php artisan test`
- `php artisan migrate --database=reportes` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f840819483339aac42cda53ccdf1