### PR TITLE
Use reportes connection in menu validation and confirm menu deletes

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Menu;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class MenuController extends Controller
 {
@@ -27,7 +26,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');
@@ -51,7 +50,7 @@ class MenuController extends Controller
             'url' => ['nullable', 'string'],
             'opcion' => ['required', 'string'],
             'icono' => ['nullable', 'string'],
-            'idmenupadre' => ['nullable', 'integer', Rule::exists('menu', 'id')->connection('reportes')],
+            'idmenupadre' => ['nullable', 'integer', 'exists:reportes.menu,id'],
             'activo' => ['nullable', 'boolean'],
         ]);
         $data['activo'] = $request->boolean('activo');

--- a/public/css/menus.css
+++ b/public/css/menus.css
@@ -1,7 +1,3 @@
-.menu-tree ul {
-    list-style: none;
-    padding-left: 1rem;
-}
-.menu-tree li {
-    margin: 0.25rem 0;
+.menu-tree .menu-toggle {
+    width: 1.5rem;
 }

--- a/public/js/menus.js
+++ b/public/js/menus.js
@@ -1,11 +1,47 @@
 document.addEventListener('DOMContentLoaded', function () {
+    function hideChildren(id) {
+        document.querySelectorAll(`.parent-${id}`).forEach(row => {
+            row.classList.add('d-none');
+            const toggle = row.querySelector('.menu-toggle');
+            if (toggle) toggle.textContent = '+';
+            hideChildren(row.dataset.menuId);
+        });
+    }
+
     document.querySelectorAll('.menu-toggle').forEach(function (btn) {
         btn.addEventListener('click', function () {
-            const target = document.querySelector(this.dataset.target);
-            if (target) {
-                target.classList.toggle('d-none');
-                this.textContent = target.classList.contains('d-none') ? '+' : '-';
+            const id = this.dataset.id;
+            const children = document.querySelectorAll(`.parent-${id}`);
+            if (children.length === 0) return;
+            const anyVisible = Array.from(children).some(row => !row.classList.contains('d-none'));
+            if (anyVisible) {
+                hideChildren(id);
+                this.textContent = '+';
+            } else {
+                children.forEach(row => row.classList.remove('d-none'));
+                this.textContent = '-';
             }
+        });
+    });
+
+    document.querySelectorAll('.delete-menu-btn').forEach(function (btn) {
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            const form = this.closest('form');
+            Swal.fire({
+                title: '¿Eliminar?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí, eliminar',
+                cancelButtonText: 'Cancelar'
+            }).then(result => {
+                if (result.isConfirmed) {
+                    document.querySelector('.spinner-overlay').classList.remove('d-none');
+                    form.submit();
+                } else {
+                    document.querySelector('.spinner-overlay').classList.add('d-none');
+                }
+            });
         });
     });
 });

--- a/resources/views/menus/form.blade.php
+++ b/resources/views/menus/form.blade.php
@@ -5,42 +5,48 @@
 @endsection
 
 @section('content')
-<h3>{{ isset($menu) ? 'Editar' : 'Nuevo' }} Menú</h3>
-<form method="POST" action="{{ isset($menu) ? route('menus.update', $menu) : route('menus.store') }}">
-    @csrf
-    @if(isset($menu))
-        @method('PUT')
-    @endif
-    <div class="mb-3">
-        <label class="form-label">Opción</label>
-        <input type="text" name="opcion" class="form-control" value="{{ old('opcion', $menu->opcion ?? '') }}" required>
+<div class="card">
+    <div class="card-header">
+        <h3 class="mb-0">{{ isset($menu) ? 'Editar' : 'Nuevo' }} Menú</h3>
     </div>
-    <div class="mb-3">
-        <label class="form-label">URL</label>
-        <input type="text" name="url" class="form-control" value="{{ old('url', $menu->url ?? '') }}">
+    <div class="card-body">
+        <form method="POST" action="{{ isset($menu) ? route('menus.update', $menu) : route('menus.store') }}">
+            @csrf
+            @if(isset($menu))
+                @method('PUT')
+            @endif
+            <div class="mb-3">
+                <label class="form-label">Opción</label>
+                <input type="text" name="opcion" class="form-control" value="{{ old('opcion', $menu->opcion ?? '') }}" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">URL</label>
+                <input type="text" name="url" class="form-control" value="{{ old('url', $menu->url ?? '') }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Icono</label>
+                <input type="text" name="icono" class="form-control" value="{{ old('icono', $menu->icono ?? '') }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Menú Padre</label>
+                <select name="idmenupadre" class="form-control">
+                    <option value="">Seleccione...</option>
+                    @foreach($menus as $m)
+                        <option value="{{ $m->id }}" @selected(old('idmenupadre', $menu->idmenupadre ?? '') == $m->id)>{{ $m->opcion }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="mb-3 form-check">
+                <input type="hidden" name="activo" value="0">
+                <input type="checkbox" name="activo" value="1" class="form-check-input" id="activo" {{ old('activo', $menu->activo ?? true) ? 'checked' : '' }}>
+                <label class="form-check-label" for="activo">Activo</label>
+            </div>
+            @if($errors->any())
+                <div class="alert alert-danger">{{ $errors->first() }}</div>
+            @endif
+            <button type="submit" class="btn btn-primary">Guardar</button>
+            <a href="{{ route('menus.index') }}" class="btn btn-secondary">Cancelar</a>
+        </form>
     </div>
-    <div class="mb-3">
-        <label class="form-label">Icono</label>
-        <input type="text" name="icono" class="form-control" value="{{ old('icono', $menu->icono ?? '') }}">
-    </div>
-    <div class="mb-3">
-        <label class="form-label">Menú Padre</label>
-        <select name="idmenupadre" class="form-control">
-            <option value="">Seleccione...</option>
-            @foreach($menus as $m)
-                <option value="{{ $m->id }}" @selected(old('idmenupadre', $menu->idmenupadre ?? '') == $m->id)>{{ $m->opcion }}</option>
-            @endforeach
-        </select>
-    </div>
-    <div class="mb-3 form-check">
-        <input type="hidden" name="activo" value="0">
-        <input type="checkbox" name="activo" value="1" class="form-check-input" id="activo" {{ old('activo', $menu->activo ?? true) ? 'checked' : '' }}>
-        <label class="form-check-label" for="activo">Activo</label>
-    </div>
-    @if($errors->any())
-        <div class="alert alert-danger">{{ $errors->first() }}</div>
-    @endif
-    <button type="submit" class="btn btn-primary">Guardar</button>
-    <a href="{{ route('menus.index') }}" class="btn btn-secondary">Cancelar</a>
-</form>
+</div>
 @endsection

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -6,14 +6,19 @@
 
 @section('content')
 <link rel="stylesheet" href="{{ asset('css/menus.css') }}">
-<div class="d-flex justify-content-between mb-3">
-    <h3>Menús</h3>
-    <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="mb-0">Menús</h3>
+        <a href="{{ route('menus.create') }}" class="btn btn-primary">Nuevo</a>
+    </div>
+    <div class="card-body">
+        <table class="table table-sm">
+            <tbody class="menu-tree">
+                @include('menus.tree', ['menus' => $menus, 'level' => 0])
+            </tbody>
+        </table>
+    </div>
 </div>
-
-<ul class="menu-tree list-unstyled">
-    @include('menus.tree', ['menus' => $menus])
-</ul>
 @endsection
 
 @section('scripts')

--- a/resources/views/menus/tree.blade.php
+++ b/resources/views/menus/tree.blade.php
@@ -1,18 +1,20 @@
 @foreach($menus as $menu)
-    <li>
-        <div class="d-flex align-items-center mb-1">
+    <tr data-menu-id="{{ $menu->id }}" class="{{ isset($parent) ? 'd-none parent-'.$parent : '' }}">
+        <td style="padding-left: {{ ($level ?? 0) * 20 }}px;">
             @if($menu->children->isNotEmpty())
-                <button class="btn btn-sm btn-link p-0 me-1 menu-toggle" data-target="#children-{{ $menu->id }}">-</button>
+                <button class="btn btn-sm btn-link p-0 me-1 menu-toggle" data-id="{{ $menu->id }}">-</button>
             @else
                 <span class="me-3"></span>
             @endif
-            <span class="flex-grow-1 {{ $menu->activo ? '' : 'text-muted' }}">{{ $menu->opcion }}</span>
+            <span class="{{ $menu->activo ? '' : 'text-muted' }}">{{ $menu->opcion }}</span>
+        </td>
+        <td class="text-end">
             <div class="btn-group btn-group-sm">
                 <a href="{{ route('menus.edit', $menu) }}" class="btn btn-secondary">Editar</a>
-                <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline delete-menu-form">
                     @csrf
                     @method('DELETE')
-                    <button type="submit" class="btn btn-danger">Eliminar</button>
+                    <button type="submit" class="btn btn-danger delete-menu-btn">Eliminar</button>
                 </form>
                 <form action="{{ route('menus.toggle', $menu) }}" method="POST" class="d-inline">
                     @csrf
@@ -20,11 +22,9 @@
                     <button type="submit" class="btn btn-{{ $menu->activo ? 'warning' : 'success' }}">{{ $menu->activo ? 'Desactivar' : 'Activar' }}</button>
                 </form>
             </div>
-        </div>
-        @if($menu->children->isNotEmpty())
-            <ul id="children-{{ $menu->id }}" class="ms-4">
-                @include('menus.tree', ['menus' => $menu->children])
-            </ul>
-        @endif
-    </li>
+        </td>
+    </tr>
+    @if($menu->children->isNotEmpty())
+        @include('menus.tree', ['menus' => $menu->children, 'parent' => $menu->id, 'level' => ($level ?? 0) + 1])
+    @endif
 @endforeach


### PR DESCRIPTION
## Summary
- reference reportes connection in MenuController `idmenupadre` validation
- prompt for SweetAlert confirmation before menu deletion and reset spinner on cancel
- wrap Menu CRUD pages in Bootstrap cards and render menu tree as table rows with collapsible levels

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/ISOSPAM/vendor/autoload.php')*
- `php artisan migrate --database=reportes` *(fails: Failed opening required '/workspace/ISOSPAM/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f840819483339aac42cda53ccdf1