### PR TITLE
Enable extra small buttons in menus

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -33,3 +33,8 @@ body.sidebar-collapsed .menu-text {
 {
     height: 35px;
 }
+
+.btn-xs {
+    padding: 0.15rem 0.35rem;
+    font-size: 0.75rem;
+}

--- a/resources/views/menus/tree.blade.php
+++ b/resources/views/menus/tree.blade.php
@@ -9,17 +9,17 @@
             <span class="{{ $menu->activo ? '' : 'text-muted' }}">{{ $menu->opcion }}</span>
         </td>
         <td class="text-end" style="width: 200px;">
-            <div class="btn-group btn-group-sm">
-                <a href="{{ route('menus.edit', $menu) }}" class="btn btn-secondary">Editar</a>
+            <div class="btn-group">
+                <a href="{{ route('menus.edit', $menu) }}" class="btn btn-secondary btn-xs">Editar</a>
                 <form action="{{ route('menus.destroy', $menu) }}" method="POST" class="d-inline delete-menu-form">
                     @csrf
                     @method('DELETE')
-                    <button type="submit" class="btn btn-danger delete-menu-btn">Eliminar</button>
+                    <button type="submit" class="btn btn-danger btn-xs delete-menu-btn">Eliminar</button>
                 </form>
                 <form action="{{ route('menus.toggle', $menu) }}" method="POST" class="d-inline">
                     @csrf
                     @method('PATCH')
-                    <button type="submit" class="btn btn-{{ $menu->activo ? 'warning' : 'success' }}">{{ $menu->activo ? 'Desactivar' : 'Activar' }}</button>
+                    <button type="submit" class="btn btn-{{ $menu->activo ? 'warning' : 'success' }} btn-xs">{{ $menu->activo ? 'Desactivar' : 'Activar' }}</button>
                 </form>
             </div>
         </td>


### PR DESCRIPTION
## Summary
- Remove `btn-group-sm` wrapper and apply `btn-xs` classes to menu action buttons
- Add `.btn-xs` rule to dashboard stylesheet for extra-small button styling

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b9074045ac8333a9f38627f83c69d5