### PR TITLE
Wrap RolMenu CRUD in Bootstrap card and add role filter

### DIFF
--- a/app/Http/Controllers/RolMenuController.php
+++ b/app/Http/Controllers/RolMenuController.php
@@ -11,12 +11,19 @@ class RolMenuController extends Controller
     {
     }
 
-    public function index()
+    public function index(Request $request)
     {
-        $response = $this->apiService->get('/rolmenu');
+        $roleId = $request->query('idrol');
+        $query = $roleId ? ['idrol' => $roleId] : [];
+        $response = $this->apiService->get('/rolmenu', $query);
         $items = $response->successful() ? $response->json() : [];
+        if ($roleId) {
+            $items = array_filter($items, fn($item) => ($item['idrol'] ?? null) == $roleId);
+        }
         return view('rolmenu.index', [
             'items' => $items,
+            'roles' => $this->getRoles(),
+            'selectedRole' => $roleId,
         ]);
     }
 

--- a/resources/views/rolmenu/form.blade.php
+++ b/resources/views/rolmenu/form.blade.php
@@ -6,44 +6,50 @@
 
 
 @section('content')
-<h3>{{ isset($item) ? 'Editar' : 'Nueva' }} Asignación Menú a Rol</h3>
-<form method="POST" action="{{ isset($item) ? route('rolmenu.update', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) : route('rolmenu.store') }}">
-    @csrf
-    @if(isset($item))
-        @method('PUT')
-    @endif
-    <div class="mb-3">
-        <label class="form-label">Rol</label>
-        <select name="idrol" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
-            <option value="">Seleccione...</option>
-            @foreach($roles as $rol)
-                <option value="{{ $rol['id'] }}" @selected(old('idrol', $item['idrol'] ?? $rolMenuId ?? '') == $rol['id'])>{{ $rol['nombrerol'] ?? $rol['id'] }}</option>
-            @endforeach
-        </select>
-        @if(isset($item))
-            <input type="hidden" name="idrol" value="{{ $item['idrol'] }}">
-        @endif
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">{{ isset($item) ? 'Editar' : 'Nueva' }} Asignación Menú a Rol</h3>
     </div>
-    <div class="mb-3">
-        <label class="form-label">Menú</label>
-        <select name="idmenu" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
-            <option value="">Seleccione...</option>
-            @foreach($menus as $m)
-                <option value="{{ $m['id'] }}" @selected(old('idmenu', $item['idmenu'] ?? '') == $m['id'])>{{ $m['opcion'] ?? $m['id'] }}</option>
-            @endforeach
-        </select>
-        @if(isset($item))
-            <input type="hidden" name="idmenu" value="{{ $item['idmenu'] }}">
-        @endif
+    <div class="card-body">
+        <form method="POST" action="{{ isset($item) ? route('rolmenu.update', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) : route('rolmenu.store') }}">
+            @csrf
+            @if(isset($item))
+                @method('PUT')
+            @endif
+            <div class="mb-3">
+                <label class="form-label">Rol</label>
+                <select name="idrol" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
+                    <option value="">Seleccione...</option>
+                    @foreach($roles as $rol)
+                        <option value="{{ $rol['id'] }}" @selected(old('idrol', $item['idrol'] ?? $rolMenuId ?? '') == $rol['id'])>{{ $rol['nombrerol'] ?? $rol['id'] }}</option>
+                    @endforeach
+                </select>
+                @if(isset($item))
+                    <input type="hidden" name="idrol" value="{{ $item['idrol'] }}">
+                @endif
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Menú</label>
+                <select name="idmenu" class="form-control" {{ isset($item) ? 'disabled' : '' }} required>
+                    <option value="">Seleccione...</option>
+                    @foreach($menus as $m)
+                        <option value="{{ $m['id'] }}" @selected(old('idmenu', $item['idmenu'] ?? '') == $m['id'])>{{ $m['opcion'] ?? $m['id'] }}</option>
+                    @endforeach
+                </select>
+                @if(isset($item))
+                    <input type="hidden" name="idmenu" value="{{ $item['idmenu'] }}">
+                @endif
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Acceso</label>
+                <input type="number" name="acceso" class="form-control" value="{{ old('acceso', $item['acceso'] ?? 0) }}" required>
+            </div>
+            @if($errors->any())
+                <div class="alert alert-danger">{{ $errors->first() }}</div>
+            @endif
+            <button type="submit" class="btn btn-primary">Guardar</button>
+            <a href="{{ route('rolmenu.index') }}" class="btn btn-secondary">Cancelar</a>
+        </form>
     </div>
-    <div class="mb-3">
-        <label class="form-label">Acceso</label>
-        <input type="number" name="acceso" class="form-control" value="{{ old('acceso', $item['acceso'] ?? 0) }}" required>
-    </div>
-    @if($errors->any())
-        <div class="alert alert-danger">{{ $errors->first() }}</div>
-    @endif
-    <button type="submit" class="btn btn-primary">Guardar</button>
-    <a href="{{ route('rolmenu.index') }}" class="btn btn-secondary">Cancelar</a>
-</form>
+</div>
 @endsection

--- a/resources/views/rolmenu/index.blade.php
+++ b/resources/views/rolmenu/index.blade.php
@@ -5,39 +5,53 @@
 @endsection
 
 @section('content')
-<div class="d-flex justify-content-between mb-3">
-    <h3>Menús por Rol</h3>
-    <a href="{{ route('rolmenu.create') }}" class="btn btn-primary">Nuevo</a>
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="card-title">Menús por Rol</h3>
+        <a href="{{ route('rolmenu.create') }}" class="btn btn-primary">Nuevo</a>
+    </div>
+    <div class="card-body">
+        <form method="GET" class="mb-3">
+            <div class="row">
+                <div class="col-md-4">
+                    <select name="idrol" class="form-control" onchange="this.form.submit()">
+                        <option value="">Todos los roles</option>
+                        @foreach($roles as $rol)
+                            <option value="{{ $rol['id'] }}" @selected($selectedRole == $rol['id'])>{{ $rol['nombrerol'] ?? $rol['id'] }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+        </form>
+        <table class="table table-dark table-striped table-compact">
+            <thead>
+                <tr>
+                    <th>Rol</th>
+                    <th>Menú</th>
+                    <th>Acceso</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($items as $item)
+                <tr>
+                    <td>{{ $item['nombre_rol'] ?? $item['idrol'] }}</td>
+                    <td>{{ $item['opcion_menu'] ?? $item['idmenu'] }}</td>
+                    <td>{{ $item['acceso'] }}</td>
+                    <td class="text-right">
+                        <a href="{{ route('rolmenu.edit', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" class="btn btn-xs btn-secondary">Editar</a>
+                        <form action="{{ route('rolmenu.destroy', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-xs btn-danger">Eliminar</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    </div>
 </div>
-
-
-<table class="table table-dark table-striped table-compact">
-    <thead>
-        <tr>
-            <th>Rol</th>
-            <th>Menú</th>
-            <th>Acceso</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach($items as $item)
-        <tr>
-            <td>{{ $item['nombre_rol'] ?? $item['idrol'] }}</td>
-            <td>{{ $item['opcion_menu'] ?? $item['idmenu'] }}</td>
-            <td>{{ $item['acceso'] }}</td>
-            <td class="text-right">
-                <a href="{{ route('rolmenu.edit', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" class="btn btn-xs btn-secondary">Editar</a>
-                <form action="{{ route('rolmenu.destroy', ['idrol' => $item['idrol'], 'idmenu' => $item['idmenu']]) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Eliminar?');">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-xs btn-danger">Eliminar</button>
-                </form>
-            </td>
-        </tr>
-    @endforeach
-    </tbody>
-</table>
 @endsection
 
 @section('scripts')


### PR DESCRIPTION
## Summary
- Wrap RolMenu index and form in Bootstrap cards
- Add role dropdown filter to Menús por Rol listing
- Adjust controller to filter records by selected role

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `php -l app/Http/Controllers/RolMenuController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9167b43e08333af1df8ff9b5e9079