### PR TITLE
Implement role selection and session management

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -32,6 +32,18 @@ class LoginController extends Controller
         return back()->withErrors(['username' => 'Credenciales incorrectas'])->withInput();
     }
 
+    public function selectRole(Request $request)
+    {
+        $idrol = $request->input('idrol');
+        $roles = session('roles', []);
+        $selected = collect($roles)->firstWhere('idrol', $idrol);
+        if ($selected) {
+            session(['active_role' => $selected]);
+        }
+
+        return redirect('/');
+    }
+
     public function logout()
     {
         Session::flush();

--- a/app/Http/Middleware/EnsureLoggedIn.php
+++ b/app/Http/Middleware/EnsureLoggedIn.php
@@ -17,6 +17,10 @@ class EnsureLoggedIn
             return redirect()->route('login');
         }
 
+        if (!session()->has('active_role') && !$request->is('roles/seleccionar')) {
+            return redirect()->route('roles.seleccionar');
+        }
+
         return $next($request);
     }
 }

--- a/resources/views/roles/seleccionar.blade.php
+++ b/resources/views/roles/seleccionar.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('spinner')
+    <x-spinner />
+@endsection
+
+@section('body-class', 'hold-transition login-page dark-mode')
+@section('container-class', 'login-box')
+
+@section('content')
+<div class="card card-outline card-primary">
+    <div class="card-body login-card-body">
+        <p class="login-box-msg">Seleccionar rol</p>
+        <form method="POST" action="{{ url('roles/seleccionar') }}">
+            @csrf
+            <div class="form-group">
+                <label for="idrol">Rol</label>
+                <select name="idrol" id="idrol" class="form-control" required>
+                    @foreach(session('roles', []) as $rol)
+                        <option value="{{ $rol['idrol'] }}">{{ $rol['nombrerol'] ?? $rol['idrol'] }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Seleccionar</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,9 @@ Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
 Route::post('/login', [LoginController::class, 'login']);
 Route::get('/logout', [LoginController::class, 'logout'])->middleware('ensure.logged.in');
 
+Route::view('roles/seleccionar', 'roles.seleccionar')->name('roles.seleccionar')->middleware('ensure.logged.in');
+Route::post('roles/seleccionar', [LoginController::class, 'selectRole'])->middleware('ensure.logged.in');
+
 Route::middleware('ensure.logged.in')->group(function () {
     Route::resource('embarcaciones', EmbarcacionController::class)->except(['show']);
     Route::resource('campanias', CampaniaController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- Add `selectRole` handler to store chosen role in session
- Provide role selection view and routes
- Redirect users without active role to the selection page

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b919eb077c8333a96ecd6b5c0f4c25