### PR TITLE
Use role id instead of idrol for session selection

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -34,9 +34,9 @@ class LoginController extends Controller
 
     public function selectRole(Request $request)
     {
-        $idrol = $request->input('idrol');
+        $id = $request->input('id');
         $roles = session('roles', []);
-        $selected = collect($roles)->firstWhere('idrol', $idrol);
+        $selected = collect($roles)->firstWhere('id', $id);
         if ($selected) {
             session(['active_role' => $selected]);
         }

--- a/resources/views/roles/seleccionar.blade.php
+++ b/resources/views/roles/seleccionar.blade.php
@@ -14,10 +14,10 @@
         <form method="POST" action="{{ url('roles/seleccionar') }}">
             @csrf
             <div class="form-group">
-                <label for="idrol">Rol</label>
-                <select name="idrol" id="idrol" class="form-control" required>
+                <label for="id">Rol</label>
+                <select name="id" id="id" class="form-control" required>
                     @foreach(session('roles', []) as $rol)
-                        <option value="{{ $rol['idrol'] }}">{{ $rol['nombrerol'] ?? $rol['idrol'] }}</option>
+                        <option value="{{ $rol['id'] }}">{{ $rol['nombrerol'] ?? $rol['id'] }}</option>
                     @endforeach
                 </select>
             </div>


### PR DESCRIPTION
## Summary
- Use `id` field instead of `idrol` when selecting a role
- Update login controller to locate roles by `id`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b91b6740c0833383dc31506c4d51a5