### PR TITLE
Store selected role and menu in session

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -37,7 +37,13 @@ class LoginController extends Controller
         $id = $request->input('id');
         $roles = session('roles', []);
         $selected = collect($roles)->firstWhere('id', $id);
+
         if ($selected) {
+            $menuResponse = $this->apiService->get('/rolmenu', ['idrol' => $id]);
+            if ($menuResponse->successful()) {
+                $selected['menu'] = $menuResponse->json();
+            }
+
             session(['active_role' => $selected]);
         }
 


### PR DESCRIPTION
## Summary
- Retrieve selected role's menu from API and store full role in `session('active_role')`
- Ensure role selection view posts the `id` field as expected

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b91c0d77e88333b5c4e877fe3a2c92