### PR TITLE
Normalize menu keys for sidebar rendering

### DIFF
--- a/app/View/Components/MenuTree.php
+++ b/app/View/Components/MenuTree.php
@@ -30,7 +30,17 @@ class MenuTree extends Component
      */
     public function __construct(iterable $menus, $parentId = null)
     {
-        $this->menus = collect($menus)->map(fn ($item) => (object) $item);
+        $this->menus = collect($menus)->map(function ($item) {
+            $item = (array) $item;
+
+            return (object) [
+                'id' => $item['id'] ?? $item['idmenu'] ?? null,
+                'opcion' => $item['opcion'] ?? $item['opcion_menu'] ?? null,
+                'url' => $item['url'] ?? $item['url_menu'] ?? null,
+                'icono' => $item['icono'] ?? $item['icono_menu'] ?? null,
+                'idmenupadre' => $item['idmenupadre'] ?? $item['idmenu_padre'] ?? null,
+            ];
+        });
         $this->parentId = $parentId;
     }
 


### PR DESCRIPTION
## Summary
- Map menu items to standardized keys in `MenuTree` component

## Testing
- `php artisan tinker --execute="session(['active_role' => ['menu' => [['idmenu'=>1,'opcion_menu'=>'Inicio','url_menu'=>'/home','icono_menu'=>'fas fa-home','idmenupadre'=>null]]]]); echo view('layouts.dashboard')->render();"`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b91f1f0c508333b80ddf117b7d8c74