### PR TITLE
Use recursive menu component on home page

### DIFF
--- a/app/View/Components/MenuTree.php
+++ b/app/View/Components/MenuTree.php
@@ -33,12 +33,15 @@ class MenuTree extends Component
         $this->menus = collect($menus)->map(function ($item) {
             $item = (array) $item;
 
+            $id = $item['id'] ?? $item['idmenu'] ?? null;
+            $idmenupadre = $item['idmenupadre'] ?? $item['idmenu_padre'] ?? null;
+
             return (object) [
-                'id' => $item['id'] ?? $item['idmenu'] ?? null,
+                'id' => is_numeric($id) ? (int) $id : null,
                 'opcion' => $item['opcion'] ?? $item['opcion_menu'] ?? null,
                 'url' => $item['url'] ?? $item['url_menu'] ?? null,
                 'icono' => $item['icono'] ?? $item['icono_menu'] ?? null,
-                'idmenupadre' => $item['idmenupadre'] ?? $item['idmenu_padre'] ?? null,
+                'idmenupadre' => is_numeric($idmenupadre) ? (int) $idmenupadre : null,
             ];
         });
         $this->parentId = $parentId;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -27,9 +27,7 @@
                                     <strong>{{ $rol['nombrerol'] ?? '' }}</strong>
                                     @if(!empty($rol['menu']))
                                         <ul class="ml-3 mt-1">
-                                            @foreach($rol['menu'] as $menu)
-                                                <li>{{ $menu['opcion'] ?? '' }}</li>
-                                            @endforeach
+                                            <x-menu-tree :menus="$rol['menu']" />
                                         </ul>
                                     @endif
                                 </div>


### PR DESCRIPTION
## Summary
- Switch home page role menus to recursive `<x-menu-tree>` component for consistent display
- Cast `id` and `idmenupadre` to integers in `MenuTree` component to avoid failed comparisons

## Testing
- `php -l app/View/Components/MenuTree.php`
- `php -l resources/views/home.blade.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b921d5eaf88333ba87d2432288249e