### PR TITLE
Cast menu identifiers to integers

### DIFF
--- a/app/View/Components/MenuTree.php
+++ b/app/View/Components/MenuTree.php
@@ -33,15 +33,12 @@ class MenuTree extends Component
         $this->menus = collect($menus)->map(function ($item) {
             $item = (array) $item;
 
-            $id = $item['id'] ?? $item['idmenu'] ?? null;
-            $idmenupadre = $item['idmenupadre'] ?? $item['idmenu_padre'] ?? null;
-
             return (object) [
-                'id' => is_numeric($id) ? (int) $id : null,
+                'id' => isset($item['id']) ? (int)$item['id'] : (isset($item['idmenu']) ? (int)$item['idmenu'] : null),
                 'opcion' => $item['opcion'] ?? $item['opcion_menu'] ?? null,
                 'url' => $item['url'] ?? $item['url_menu'] ?? null,
                 'icono' => $item['icono'] ?? $item['icono_menu'] ?? null,
-                'idmenupadre' => is_numeric($idmenupadre) ? (int) $idmenupadre : null,
+                'idmenupadre' => isset($item['idmenupadre']) ? (int)$item['idmenupadre'] : (isset($item['idmenu_padre']) ? (int)$item['idmenu_padre'] : null),
             ];
         });
         $this->parentId = $parentId;


### PR DESCRIPTION
## Summary
- ensure menu IDs are treated as integers to preserve hierarchy

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b9226e6bf0833387cf2a14ba0db724