### PR TITLE
Document menu-tree component props and refine tree rendering

### DIFF
--- a/resources/views/components/menu-tree.blade.php
+++ b/resources/views/components/menu-tree.blade.php
@@ -1,3 +1,5 @@
+@props(['menus', 'parentId' => null])
+
 @php
     $children = $menus->where('idmenupadre', $parentId);
 @endphp
@@ -7,20 +9,26 @@
         $hasChildren = $menus->where('idmenupadre', $menu->id)->isNotEmpty();
         $href = $menu->url && $menu->url !== '#' ? url($menu->url) : '#';
     @endphp
-    <li class="nav-item {{ $hasChildren ? 'has-treeview' : '' }}">
-        <a href="{{ $href }}" class="nav-link">
-            <i class="nav-icon {{ $menu->icono }}"></i>
-            <p>
-                {{ $menu->opcion }}
-                @if ($hasChildren)
+
+    @if ($hasChildren)
+        <li class="nav-item has-treeview">
+            <a href="{{ $href }}" class="nav-link">
+                <i class="nav-icon {{ $menu->icono }}"></i>
+                <p>
+                    {{ $menu->opcion }}
                     <i class="right fas fa-angle-left"></i>
-                @endif
-            </p>
-        </a>
-        @if ($hasChildren)
+                </p>
+            </a>
             <ul class="nav nav-treeview">
                 <x-menu-tree :menus="$menus" :parent-id="$menu->id" />
             </ul>
-        @endif
-    </li>
+        </li>
+    @else
+        <li class="nav-item">
+            <a href="{{ $href }}" class="nav-link">
+                <i class="nav-icon {{ $menu->icono }}"></i>
+                <p>{{ $menu->opcion }}</p>
+            </a>
+        </li>
+    @endif
 @endforeach


### PR DESCRIPTION
## Summary
- document `menus` and `parentId` props with default parent value
- render nested items only when children exist and wrap recursive output in `nav-treeview`

## Testing
- `composer test`
- manual render of menu-tree component

------
https://chatgpt.com/codex/tasks/task_e_68b92b0647608333af46e33813111a15