### PR TITLE
Ensure menu icons and routes render correctly

### DIFF
--- a/resources/views/components/menu-tree.blade.php
+++ b/resources/views/components/menu-tree.blade.php
@@ -1,19 +1,34 @@
 @props(['menus', 'parentId' => null])
 
 @php
+    use Illuminate\Support\Str;
+
     $children = $menus->where('idmenupadre', $parentId);
 @endphp
 
 @foreach ($children as $menu)
     @php
         $hasChildren = $menus->where('idmenupadre', $menu->id)->isNotEmpty();
-        $href = $menu->url && $menu->url !== '#' ? url($menu->url) : '#';
+
+        $href = '#';
+        if ($menu->url && $menu->url !== '#') {
+            $href = Route::has($menu->url) ? route($menu->url) : url($menu->url);
+        }
+
+        $icon = trim($menu->icono);
+        if ($icon) {
+            if (!Str::contains($icon, 'fa-')) {
+                $icon = 'fas fa-' . $icon;
+            } elseif (!Str::startsWith($icon, ['fas', 'far', 'fab', 'fal', 'fad'])) {
+                $icon = 'fas ' . $icon;
+            }
+        }
     @endphp
 
     @if ($hasChildren)
         <li class="nav-item has-treeview">
             <a href="{{ $href }}" class="nav-link">
-                <i class="nav-icon {{ $menu->icono }}"></i>
+                <i class="nav-icon {{ $icon }}"></i>
                 <p>
                     {{ $menu->opcion }}
                     <i class="right fas fa-angle-left"></i>
@@ -26,7 +41,7 @@
     @else
         <li class="nav-item">
             <a href="{{ $href }}" class="nav-link">
-                <i class="nav-icon {{ $menu->icono }}"></i>
+                <i class="nav-icon {{ $icon }}"></i>
                 <p>{{ $menu->opcion }}</p>
             </a>
         </li>


### PR DESCRIPTION
## Summary
- Use route() when menu item URL stores a named route
- Auto-prefix menu icon classes with `fas`/`fa` when missing

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b92bbe46d083339f0d2e57ed5b204b