### PR TITLE
Expand menu key aliases for API response

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -62,13 +62,13 @@ class LoginController extends Controller
         return array_map(function ($item) {
             $item = (array) $item;
 
-            foreach (['idmenupadre', 'idmenu_padre', 'idMenuPadre', 'id_menu_padre'] as $key) {
+            foreach (['idmenupadre', 'idmenu_padre', 'idMenuPadre', 'id_menu_padre', 'parent_id', 'parentId'] as $key) {
                 if (array_key_exists($key, $item)) {
                     $item[$key] = $item[$key] === 0 ? null : $item[$key];
                 }
             }
 
-            foreach (['children', 'hijos', 'menu_hijos', 'menu_hijo', 'submenu', 'submenus'] as $childKey) {
+            foreach (['children', 'hijos', 'menu_hijos', 'menu_hijo', 'submenu', 'submenus', 'childs', 'items'] as $childKey) {
                 if (!empty($item[$childKey]) && is_array($item[$childKey])) {
                     $item[$childKey] = $this->normalizeMenus($item[$childKey]);
                 }

--- a/app/View/Components/MenuTree.php
+++ b/app/View/Components/MenuTree.php
@@ -37,12 +37,12 @@ class MenuTree extends Component
         foreach ($menus as $item) {
             $item = (array) $item;
 
-            $id = $this->firstValue($item, ['id', 'idmenu', 'id_menu', 'idMenu']);
+            $id = $this->firstValue($item, ['id', 'idmenu', 'id_menu', 'idMenu', 'menu_id']);
             $id = $id !== null ? (int) $id : null;
 
             $parent = $this->firstValue(
                 $item,
-                ['idmenupadre', 'idmenu_padre', 'idMenuPadre', 'id_menu_padre']
+                ['idmenupadre', 'idmenu_padre', 'idMenuPadre', 'id_menu_padre', 'parent_id', 'parentId']
             );
             $parent = $parent !== null ? (int) $parent : $parentId;
             $parent = $parent === 0 ? null : $parent;
@@ -50,8 +50,8 @@ class MenuTree extends Component
             $menu = (object) [
                 'id' => $id,
                 'opcion' => $this->firstValue($item, ['opcion', 'opcion_menu']),
-                'url' => $this->firstValue($item, ['url', 'url_menu']),
-                'icono' => $this->firstValue($item, ['icono', 'icono_menu', 'icon']),
+                'url' => $this->firstValue($item, ['url', 'url_menu', 'route']),
+                'icono' => $this->firstValue($item, ['icono', 'icono_menu', 'icon', 'icon_class']),
                 'idmenupadre' => $parent,
             ];
 

--- a/tests/Unit/MenuNormalizationTest.php
+++ b/tests/Unit/MenuNormalizationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\View\Components\MenuTree;
+use App\Http\Controllers\LoginController;
+use App\Services\ApiService;
+use Mockery;
+use ReflectionClass;
+use Tests\TestCase;
+
+class MenuNormalizationTest extends TestCase
+{
+    public function test_menu_tree_handles_new_attribute_names(): void
+    {
+        $menus = [
+            [
+                'id' => 1,
+                'opcion' => 'Root',
+                'route' => '/root',
+                'icon_class' => 'root-icon',
+                'parent_id' => 0,
+                'children' => [
+                    [
+                        'id' => 2,
+                        'opcion' => 'Child',
+                        'route' => '/child',
+                        'icon_class' => 'child-icon',
+                        'parent_id' => 1,
+                    ],
+                ],
+            ],
+        ];
+
+        $api = Mockery::mock(ApiService::class);
+        $controller = new LoginController($api);
+        $ref = new ReflectionClass(LoginController::class);
+        $method = $ref->getMethod('normalizeMenus');
+        $method->setAccessible(true);
+
+        $normalized = $method->invoke($controller, $menus);
+
+        // parent_id should be normalized to null when value is 0
+        $this->assertNull($normalized[0]['parent_id']);
+        $this->assertCount(1, $normalized[0]['children']);
+
+        $tree = new MenuTree($normalized);
+        $items = $tree->menus->all();
+
+        $this->assertCount(2, $items);
+        $this->assertSame(1, $items[0]->id);
+        $this->assertNull($items[0]->idmenupadre);
+        $this->assertSame('/root', $items[0]->url);
+        $this->assertSame('root-icon', $items[0]->icono);
+
+        $this->assertSame(2, $items[1]->id);
+        $this->assertSame(1, $items[1]->idmenupadre);
+        $this->assertSame('/child', $items[1]->url);
+        $this->assertSame('child-icon', $items[1]->icono);
+    }
+}


### PR DESCRIPTION
## Summary
- include additional menu key aliases like `parent_id`, `route`, and `icon_class`
- normalize new menu keys in login controller
- add unit test for menu normalization and flattening

## Testing
- `composer test`
- Attempted to fetch real `/rolmenu` endpoint via `curl -sS --http1.0 https://isospam.manabi.gob.ec/isospam/rolmenu?idrol=1 -D - -o - | head -n 20` (received `HTTP/1.1 426 Upgrade Required`)


------
https://chatgpt.com/codex/tasks/task_e_68b93114b4f48333946f8b78d3b969aa