### PR TITLE
feat: allow switching roles and dynamic menu

### DIFF
--- a/resources/views/components/menu-tree.blade.php
+++ b/resources/views/components/menu-tree.blade.php
@@ -28,7 +28,9 @@
     @if ($hasChildren)
         <li class="nav-item has-treeview">
             <a href="{{ $href }}" class="nav-link">
-                <i class="nav-icon {{ $icon }}"></i>
+                @if($icon)
+                    <i class="nav-icon {{ $icon }}"></i>
+                @endif
                 <p>
                     {{ $menu->opcion }}
                     <i class="right fas fa-angle-left"></i>
@@ -41,7 +43,9 @@
     @else
         <li class="nav-item">
             <a href="{{ $href }}" class="nav-link">
-                <i class="nav-icon {{ $icon }}"></i>
+                @if($icon)
+                    <i class="nav-icon {{ $icon }}"></i>
+                @endif
                 <p>{{ $menu->opcion }}</p>
             </a>
         </li>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -23,9 +23,23 @@
                     <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
                 </li>
             </ul>
-            <ul class="navbar-nav ml-auto">
+            <ul class="navbar-nav ml-auto align-items-center">
+                @if(session('roles'))
+                    <li class="nav-item">
+                        <form id="role-switcher" method="POST" action="{{ url('roles/seleccionar') }}" class="mb-0">
+                            @csrf
+                            <select name="id" class="form-control form-control-sm" onchange="this.form.submit()">
+                                @foreach(session('roles', []) as $rol)
+                                    <option value="{{ $rol['id'] }}" {{ session('active_role.id') == $rol['id'] ? 'selected' : '' }}>
+                                        {{ $rol['nombrerol'] ?? $rol['id'] }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </form>
+                    </li>
+                @endif
                 @if(session('user'))
-                    <li class="nav-item"><a class="btn btn-xs btn-primary" href="{{ url('/logout') }}">Cerrar sesión</a></li>
+                    <li class="nav-item ml-2"><a class="btn btn-xs btn-primary" href="{{ url('/logout') }}">Cerrar sesión</a></li>
                 @else
                     <li class="nav-item"><a class="nav-link" href="{{ url('/login') }}">Login</a></li>
                 @endif


### PR DESCRIPTION
## Summary
- enable runtime role switching with a navbar dropdown
- reuse or fetch role menus and cache them on selection
- render sidebar menus with optional icons

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b934a3aad48333bcbbab16c2541de5