### PR TITLE
Clear active role on login

### DIFF
--- a/app/Services/ApiService.php
+++ b/app/Services/ApiService.php
@@ -21,6 +21,7 @@ class ApiService
         $response = Http::post($this->baseUrl . '/login', $credentials);
 
         if ($response->successful()) {
+            Session::forget('active_role');
             $json = $response->json();
             Session::put('user', $json['persona'] ?? null);
             Session::put('token', $json['access_token'] ?? null);

--- a/tests/Unit/LoginClearsActiveRoleTest.php
+++ b/tests/Unit/LoginClearsActiveRoleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ApiService;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class LoginClearsActiveRoleTest extends TestCase
+{
+    public function test_active_role_is_cleared_on_login(): void
+    {
+        Session::start();
+        Session::put('active_role', ['menus' => ['old']]);
+
+        Http::fake([
+            'http://localhost:9090/isospam/login' => Http::response([
+                'persona' => ['name' => 'User'],
+                'access_token' => 'token',
+                'roles' => [],
+            ], 200),
+        ]);
+
+        $service = new ApiService();
+        $service->login(['email' => 'a', 'password' => 'b']);
+
+        $this->assertFalse(Session::has('active_role'));
+        $this->assertSame([], Session::get('roles'));
+    }
+}


### PR DESCRIPTION
## Summary
- Clear any previously active role when logging in
- Add unit test for login clearing active role session

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b9370cc8448333949c87e574f4a643