### PR TITLE
Support stdClass entries in menu-tree component

### DIFF
--- a/resources/views/components/menu-tree.blade.php
+++ b/resources/views/components/menu-tree.blade.php
@@ -7,7 +7,8 @@
 
 @foreach ($menus as $menu)
     @php
-        $children = $menu['children'] ?? [];
+        $menu = (array) $menu;
+        $children = (array) ($menu['children'] ?? []);
         $hasChildren = !empty($children);
         $url = $menu['url'] ?? '#';
         $href = '#';

--- a/tests/Unit/MenuTreeViewTest.php
+++ b/tests/Unit/MenuTreeViewTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class MenuTreeViewTest extends TestCase
+{
+    public function test_renders_with_arrays_and_objects(): void
+    {
+        $arrayMenus = [
+            [
+                'opcion' => 'Parent',
+                'url' => '#',
+                'children' => [
+                    ['opcion' => 'Child', 'url' => '/child']
+                ],
+            ],
+        ];
+
+        $child = new \stdClass();
+        $child->opcion = 'Child';
+        $child->url = '/child';
+
+        $parent = new \stdClass();
+        $parent->opcion = 'Parent';
+        $parent->url = '#';
+        $parent->children = [$child];
+
+        $objectMenus = [$parent];
+
+        $arrayHtml = view('components.menu-tree', ['menus' => $arrayMenus])->render();
+        $objectHtml = view('components.menu-tree', ['menus' => $objectMenus])->render();
+
+        $this->assertSame($arrayHtml, $objectHtml);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow `x-menu-tree` to handle menu items provided as arrays or `stdClass` objects by casting each entry and its children
- Verify menu rendering works for both arrays and objects

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b9f7315960833394c7d092d9fa073b