### PR TITLE
Simplify MenuTree component and add nested menu test

### DIFF
--- a/app/View/Components/MenuTree.php
+++ b/app/View/Components/MenuTree.php
@@ -2,7 +2,6 @@
 
 namespace App\View\Components;
 
-use Illuminate\Support\Collection;
 use Illuminate\View\Component;
 
 class MenuTree extends Component
@@ -10,73 +9,14 @@ class MenuTree extends Component
     /**
      * All menus available for rendering.
      */
-    public Collection $menus;
-
-    /**
-     * Parent menu id.
-     *
-     * @var int|null
-     */
-    public $parentId;
+    public array $menus;
 
     /**
      * Create a new component instance.
-     *
-     * @param  int|null  $parentId
-     * @return void
      */
-    public function __construct(iterable $menus, $parentId = null)
+    public function __construct(array $menus = [])
     {
-        $this->menus = collect();
-        $this->flattenMenus($menus);
-        $this->parentId = $parentId;
-    }
-
-    private function flattenMenus(iterable $menus, $parentId = null): void
-    {
-        foreach ($menus as $item) {
-            $item = (array) $item;
-
-            $id = $this->firstValue($item, ['id', 'idmenu', 'id_menu', 'idMenu', 'menu_id']);
-            $id = $id !== null ? (int) $id : null;
-
-            $parent = $this->firstValue(
-                $item,
-                ['idmenupadre', 'idmenu_padre', 'idMenuPadre', 'id_menu_padre', 'parent_id', 'parentId']
-            );
-            $parent = $parent !== null ? (int) $parent : $parentId;
-            $parent = $parent === 0 ? null : $parent;
-
-            $menu = (object) [
-                'id' => $id,
-                'opcion' => $this->firstValue($item, ['opcion', 'opcion_menu']),
-                'url' => $this->firstValue($item, ['url', 'url_menu', 'route']),
-                'icono' => $this->firstValue($item, ['icono', 'icono_menu', 'icon', 'icon_class']),
-                'idmenupadre' => $parent,
-            ];
-
-            $this->menus->push($menu);
-
-            $children = $this->firstValue(
-                $item,
-                ['children', 'hijos', 'menu_hijos', 'menu_hijo', 'submenu', 'submenus']
-            ) ?? [];
-
-            if (is_iterable($children)) {
-                $this->flattenMenus($children, $id);
-            }
-        }
-    }
-
-    private function firstValue(array $item, array $keys)
-    {
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $item)) {
-                return $item[$key];
-            }
-        }
-
-        return null;
+        $this->menus = $menus;
     }
 
     /**

--- a/tests/Unit/MenuTreeViewTest.php
+++ b/tests/Unit/MenuTreeViewTest.php
@@ -34,4 +34,21 @@ class MenuTreeViewTest extends TestCase
 
         $this->assertSame($arrayHtml, $objectHtml);
     }
+
+    public function test_renders_sublevels_when_menu_has_children(): void
+    {
+        $menus = [
+            [
+                'opcion' => 'Parent',
+                'url' => '#',
+                'children' => [
+                    ['opcion' => 'Child', 'url' => '/child'],
+                ],
+            ],
+        ];
+
+        $html = view('components.menu-tree', ['menus' => $menus])->render();
+
+        $this->assertStringContainsString('<ul class="nav nav-treeview">', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- Simplify MenuTree component to store provided menus without flattening
- Verify nested menu rendering via new unit test

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ba0476ea9483339636848e842ca710