### PR TITLE
Cambiar key de sesión a persona

### DIFF
--- a/app/Http/Controllers/ViajeController.php
+++ b/app/Http/Controllers/ViajeController.php
@@ -251,7 +251,7 @@ class ViajeController extends Controller
 
     public function misPorFinalizar(Request $request)
     {
-        $digitadorId = $request->query('digitador_id', session('user.idpersona'));
+        $digitadorId = $request->query('digitador_id', session('persona.idpersona'));
 
         $digitadores = $this->getPersonasPorRol('CTF');
 
@@ -454,7 +454,7 @@ class ViajeController extends Controller
 
     public function seleccionar(string $id)
     {
-        $digitadorId = session('user.idpersona');
+        $digitadorId = session('persona.idpersona');
 
         $response = $this->apiService->post(
             "/viajes/{$id}/seleccionar?viaje_id={$id}&digitador_id={$digitadorId}"

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="container-fluid">
-    @if(session('user'))
+    @if(session('persona'))
         <div class="row">
             <div class="col-md-4 mb-4">
                 <div class="card shadow-sm h-100">
@@ -10,8 +10,8 @@
                         <h5 class="card-title mb-3">Usuario</h5>
                     </div>
                     <div class="card-body">
-                        <p class="mb-1 font-weight-bold">{{ session('user.nombres') }} {{ session('user.apellidos') }}</p>
-                        <p class="mb-0 text-muted">{{ session('user.email') }}</p>
+                        <p class="mb-1 font-weight-bold">{{ session('persona.nombres') }} {{ session('persona.apellidos') }}</p>
+                        <p class="mb-0 text-muted">{{ session('persona.email') }}</p>
                     </div>
                 </div>
             </div>

--- a/tests/Feature/HomeViewShowsPersonaTest.php
+++ b/tests/Feature/HomeViewShowsPersonaTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class HomeViewShowsPersonaTest extends TestCase
+{
+    public function test_home_displays_persona_when_logged_in(): void
+    {
+        Session::start();
+        Session::put('persona', [
+            'nombres' => 'John',
+            'apellidos' => 'Doe',
+            'email' => 'john@example.com',
+        ]);
+
+        $response = $this
+            ->withoutMiddleware(\App\Http\Middleware\EnsureLoggedIn::class)
+            ->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('John Doe');
+        $response->assertSee('john@example.com');
+        $response->assertDontSee('No has iniciado sesión.');
+    }
+}


### PR DESCRIPTION
## Summary
- Replace home view's `session('user')` references with `session('persona')`
- Update ViajeController to read `session('persona.idpersona')`
- Add feature test ensuring home page shows persona info and hides login message

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ba08a29a708333abb9237d830c8d7d